### PR TITLE
Gcc 6.2 fixes

### DIFF
--- a/MPC/config/dafcompilersupport.mpb
+++ b/MPC/config/dafcompilersupport.mpb
@@ -35,6 +35,12 @@ feature(!warn_unused_variable){
   }
 }
 
+feature(no_deprecated_declarations){
+  verbatim(gnuace,top,1) { // NOTE: explicit ,1 in verbatim add = 1 means its appended
+        CCFLAGS += -Wno-deprecated-declarations
+  }
+}
+
 feature(vc_avoid_throw_warning) {
   specific(prop:microsoft) {
     DisableSpecificWarnings += 4290 // Ignore vc warnings from declarations that contain the throw clause

--- a/TAF/MulticastDiscoveryUtility/MulticastDiscoveryUtility.cpp
+++ b/TAF/MulticastDiscoveryUtility/MulticastDiscoveryUtility.cpp
@@ -199,7 +199,7 @@ namespace {
 
                         const IOP::MultipleComponentProfile &mcp(profile->tagged_components().components());
 
-                        if (ior_tags_ || verbose_ > 2) for (CORBA::ULong j = 0; j < mcp.length(); j++) {
+                        if (ior_tags_ || verbose() > 2) for (CORBA::ULong j = 0; j < mcp.length(); j++) {
                             const IOP::TaggedComponent &tc(mcp[j]);
                             char tags[16]; ACE_OS::sprintf(tags, "-Tag[%03x]:", int(tc.tag));
                             *this << '\t' << std::setw(10) << tags;
@@ -288,7 +288,7 @@ namespace {
 
         this->insert_descriptor(taf::EntityDescriptor_var(taf_server->entity_descriptor()), index);
 
-        if (properties_ || verbose_ > 1) try {
+        if (properties_ || verbose() > 1) try {
             this->insert_properties(taf_server->list_properties());
         } DAF_CATCH_ALL {}
 

--- a/TAF/taf/StringManager_T.h
+++ b/TAF/taf/StringManager_T.h
@@ -56,7 +56,15 @@ namespace TAF
         {
         }
 
-        using _string_type::operator =;
+        StringManager_T<T> & operator = (const StringManager_T<T> &s)
+        {
+            this->assign(s); return *this;
+        }
+
+        StringManager_T<T> & operator = (const _string_type &s)
+        {
+            this->assign(s); return *this;
+        }
 
         operator _var_type () const
         {

--- a/daf/DAF.cpp
+++ b/daf/DAF.cpp
@@ -132,7 +132,10 @@ namespace DAF
                 do {
                     if (i) {
                         if (i % width) {
-                            if ((i % 8) == 0) ss << ' '; continue;
+                            if ((i % 8) == 0) {
+                                ss << ' ';
+                            }
+                            continue;
                         }
                     }
 

--- a/daf/ObjectRef_T.cpp
+++ b/daf/ObjectRef_T.cpp
@@ -96,14 +96,20 @@ namespace DAF
     typename ObjectRef<T>::_in_type
     ObjectRef<T>::operator -> (void) const throw (DAF::INV_OBJREF)
     {
-        if (this->ptr_) return this->ptr_; throw DAF::INV_OBJREF();
+        if (this->ptr_) {
+            return this->ptr_;
+        }
+        throw DAF::INV_OBJREF();
     }
 
     template <typename T> inline
     typename ObjectRef<T>::_ref_type
     ObjectRef<T>::operator * (void) const throw (DAF::INV_OBJREF)
     {
-        if (this->ptr_) return *this->ptr_; throw DAF::INV_OBJREF();
+        if (this->ptr_) {
+            return *this->ptr_;
+        }
+        throw DAF::INV_OBJREF();
     }
 
     template <typename T> inline
@@ -252,7 +258,10 @@ namespace DAF
     T *
     ObjectRefOut<T>::operator -> (void) const throw (DAF::INV_OBJREF)
     {
-        if (this->ptr_) return this->ptr_; throw DAF::INV_OBJREF();
+        if (this->ptr_) {
+            return this->ptr_;
+        }
+        throw DAF::INV_OBJREF();
     }
 } // namespace DAF
 

--- a/tests/Performance/STATSData.h
+++ b/tests/Performance/STATSData.h
@@ -56,7 +56,10 @@ namespace PERF
             os << s.ident() << ":Count=" << s.timeCount_ << std::endl;
 
             for (size_t i = 0; i < s.timeCount_; i++) {
-                if (i) os << ','; os << s.timeData_[i];
+                if (i) {
+                    os << ',';
+                }
+                os << s.timeData_[i];
             }
 
             return os << std::endl;


### PR DESCRIPTION
These fixes are mostly syntax changes to keep gcc 6.2 happy without warnings. It seems GNU have tightened up their syntax parser and now give warnings/errors where they did not on previous releases. Notable cases are:
1) if (x) y; z; causes a warning so if (x) { y; } z; corrects this
2) using a 'using' to up-scope operator =; no longer works. Must fully code operator implementation now. 