### PR TITLE
Colons in path separators in linux

### DIFF
--- a/docs/html/documentation/linux_notes.html
+++ b/docs/html/documentation/linux_notes.html
@@ -54,8 +54,8 @@
                     <ul>
                         <li><pre>export DAF_ROOT = [extracted path]/LASAGNE-Core</pre></li>
                         <li><pre>export TAF_ROOT = [extracted path]/LASAGNE-Core/TAF</pre></li>
-                        <li><pre>export PATH = $PATH;[extracted path]/LASAGNE-Core/bin;[extracted path]/LASAGNE-Core/lib</pre></li>
-                        <li><pre>export LD_LIBRARY_PATH = $LD_LIBRARY_PATH;[extracted path]/LASAGNE-Core/lib</pre></li>
+                        <li><pre>export PATH = $PATH:[extracted path]/LASAGNE-Core/bin:[extracted path]/LASAGNE-Core/lib</pre></li>
+                        <li><pre>export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:[extracted path]/LASAGNE-Core/lib</pre></li>
                     </ul>
                 </li>
                 <li>Set desired features
@@ -81,8 +81,8 @@
                         <li><pre>export ACE_ROOT = [extracted path]/ACE_wrappers</pre></li>
                         <li><pre>export MPC_ROOT = [extracted path]/ACE_wrappers/MPC</pre></li>
                         <li><pre>export TAO_ROOT = [extracted path]/ACE_wrappers/TAO</pre></li>
-                        <li><pre>export PATH = $PATH;[extracted path]/ACE_wrappers/bin;[extracted path]/ACE_wrappers/lib</pre></li>
-                        <li><pre>export LD_LIBRARY_PATH = $LD_LIBRARY_PATH;[extracted path]/ACE_wrappers/lib</pre></li>
+                        <li><pre>export PATH = $PATH:[extracted path]/ACE_wrappers/bin:[extracted path]/ACE_wrappers/lib</pre></li>
+                        <li><pre>export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:[extracted path]/ACE_wrappers/lib</pre></li>
                     </ul>
                 </li>
                 <li>Create the platform configuration files
@@ -133,8 +133,8 @@ perl $ACE_ROOT/bin/mwc.pl -type gnuace $TAO_ROOT/TAO_ACE.mwc
                 <li>Set environment variables
                     <ul>
                         <li><pre>export DDS_ROOT = [extracted path]/OpenDDS</pre></li>
-                        <li><pre>export PATH = $PATH;[extracted path]/OpenDDS/bin;[extracted path]/OpenDDS/lib</pre></li>
-                        <li><pre>export LD_LIBRARY_PATH = $LD_LIBRARY_PATH;[extracted path]/OpenDDS/lib</pre></li>
+                        <li><pre>export PATH = $PATH:[extracted path]/OpenDDS/bin:[extracted path]/OpenDDS/lib</pre></li>
+                        <li><pre>export LD_LIBRARY_PATH = $LD_LIBRARY_PATH:[extracted path]/OpenDDS/lib</pre></li>
                     </ul>
                 </li>
                 <li>Generate the workspace and project files

--- a/docs/html/documentation/linux_notes.html
+++ b/docs/html/documentation/linux_notes.html
@@ -193,7 +193,7 @@ rabbitmq         = 0
                     <ul>
                         <li>For GNU make (gnuace), from the command line, run the command:
                             <pre>
-perl $ACE_ROOT%/bin/mwc.pl -type gnuace $TAF_ROOT/TAF.mwc
+perl $ACE_ROOT/bin/mwc.pl -type gnuace $TAF_ROOT/TAF.mwc
                             </pre>
                         </li>
                         <li>Alternatively, run the TAF_gnuace.sh script</li>


### PR DESCRIPTION
Hi,

The environment variable setup should have colons not semi-colons for linux.