### PR TITLE
Prefer using DAF_OS over ACE_OS to capture implementation changes

### DIFF
--- a/GCRoute/GCLocation.cpp
+++ b/GCRoute/GCLocation.cpp
@@ -133,7 +133,7 @@ namespace GCRoute
         float lng_s = float(60*(60*(lng-double(lng_d))-double(lng_m)));
 
         char str[64];
-        ACE_OS::sprintf(str, "%03d:%02d:%02f%c %03d:%02d:%02f%c",
+        DAF_OS::sprintf(str, "%03d:%02d:%02f%c %03d:%02d:%02f%c",
             lat_d,lat_m,lat_s, ((latitude() < 0.0)  ? 'S' : 'N'),
             lng_d,lng_m,lng_s, ((longitude() < 0.0) ? 'E' : 'W'));
 
@@ -152,7 +152,7 @@ namespace GCRoute
         float lng_m = float(60*(lng-double(lng_d)));
 
         char str[64];
-        ACE_OS::sprintf(str, "%d %02.04f%c %d %02.04f%c",
+        DAF_OS::sprintf(str, "%d %02.04f%c %d %02.04f%c",
             lat_d,lat_m, ((latitude() < 0.0)  ? 'S' : 'N'),
             lng_d,lng_m, ((longitude() < 0.0) ? 'E' : 'W'));
 

--- a/TAF/MulticastDiscoveryUtility/MulticastDiscoveryUtility.cpp
+++ b/TAF/MulticastDiscoveryUtility/MulticastDiscoveryUtility.cpp
@@ -85,7 +85,7 @@ namespace {
         case 'l':
             for (const ACE_TCHAR *looptime_val = get_opts.opt_arg(); looptime_val;) {
                 if (::isdigit(int(*looptime_val))) {
-                    DISCOVER_TIMOUT.set(ace_range(2, 120, ACE_OS::atoi(looptime_val)), 0);
+                    DISCOVER_TIMOUT.set(ace_range(2, 120, DAF_OS::atoi(looptime_val)), 0);
                 }
                 break;
             } break;
@@ -94,7 +94,7 @@ namespace {
         case 'v':   verbose_ = 1;
             for (const ACE_TCHAR *verbose_val = get_opts.opt_arg(); verbose_val;) {
                 if (::isdigit(int(*verbose_val))) {
-                    verbose_ = ace_range(1, 10, ACE_OS::atoi(verbose_val));
+                    verbose_ = ace_range(1, 10, DAF_OS::atoi(verbose_val));
                 }
                 break;
             } break;
@@ -102,7 +102,7 @@ namespace {
         case 'z':   debug_ = 1;
             for (const ACE_TCHAR *debug_val = get_opts.opt_arg(); debug_val;) {
                 if (::isdigit(int(*debug_val))) {
-                    debug_ = ace_range(1, 10, ACE_OS::atoi(debug_val));
+                    debug_ = ace_range(1, 10, DAF_OS::atoi(debug_val));
                 }
                 break;
             } break;
@@ -194,14 +194,14 @@ namespace {
                 for (CORBA::ULong i = 0; i < mp.profile_count(); i++) {
                     TAO_Profile *profile(mp.get_profile(i));
                     if (profile) {
-                        char iors[16]; ACE_OS::sprintf(iors, "IOR[%d]:", int(i));
+                        char iors[16]; DAF_OS::sprintf(iors, "IOR[%d]:", int(i));
                         *this << '\t' << std::setw(8) << iors << CORBA::String_var(profile->to_string()).in() << std::endl;
 
                         const IOP::MultipleComponentProfile &mcp(profile->tagged_components().components());
 
                         if (ior_tags_ || verbose() > 2) for (CORBA::ULong j = 0; j < mcp.length(); j++) {
                             const IOP::TaggedComponent &tc(mcp[j]);
-                            char tags[16]; ACE_OS::sprintf(tags, "-Tag[%03x]:", int(tc.tag));
+                            char tags[16]; DAF_OS::sprintf(tags, "-Tag[%03x]:", int(tc.tag));
                             *this << '\t' << std::setw(10) << tags;
                             const size_t tc_data_len = size_t(tc.component_data.length()); if (tc_data_len) {
                                 *this << DAF::hex_dump_data(tc.component_data.get_buffer(), tc_data_len, (tc_data_len % 32));
@@ -226,7 +226,7 @@ namespace {
 
         const char * ident_format((ed.flags_ & (1U << taf::SVC_EXECUTE)) ? ACE_TEXT("[%02d] %s\t[%s]\n") : ACE_TEXT("-->[%02d] %s\t[%s]\n"));
         {
-            char sIdent[256]; ACE_OS::sprintf(sIdent, ident_format
+            char sIdent[256]; DAF_OS::sprintf(sIdent, ident_format
                 , int(index), ed.ident_.in(), svc_flags_to_string(unsigned(ed.flags_)).c_str());
             *this << sIdent;
         }
@@ -238,7 +238,7 @@ namespace {
         }
 
         {
-            char sTime[64]; ACE_OS::sprintf(sTime, " - [elapsed %d:%02d Hrs]", run_hrs, unsigned(run_min % 60U));
+            char sTime[64]; DAF_OS::sprintf(sTime, " - [elapsed %d:%02d Hrs]", run_hrs, unsigned(run_min % 60U));
             *this << '\t' << std::setw(8) << "START:" << DAF_Date_Time(start_time) << " GMT" << sTime << std::endl;
         }
 
@@ -276,11 +276,11 @@ namespace {
 
         CORBA::String_var svc_name(taf_server->svc_name());
 
-        if (svc_name && ACE_OS::strlen(svc_name.in())) {
+        if (svc_name && DAF_OS::strlen(svc_name.in())) {
 
             char msg[BUFSIZ];
 
-            ACE_OS::sprintf(msg, ACE_TEXT("Hi there %s, Discovery Utility on '%s' can see you!!")
+            DAF_OS::sprintf(msg, ACE_TEXT("Hi there %s, Discovery Utility on '%s' can see you!!")
                 , svc_name.in(), DAF_OS::gethostname().c_str());
 
             taf_server->sendConsoleMsg(msg);

--- a/TAF/dds/DDSPubSub.cpp
+++ b/TAF/dds/DDSPubSub.cpp
@@ -232,7 +232,7 @@ namespace TAFDDS
     DDS_Topic_handle
     DDS_Topic_factory::create_topic(const DDS_DomainParticipant_handle &participant, const DDS_Type_handle &type, DDS::String_ptr topic_name)
     {
-        if (topic_name ? ACE_OS::strlen(topic_name) == 0 : true) {
+        if (topic_name ? DAF_OS::strlen(topic_name) == 0 : true) {
             DAF_THROW_EXCEPTION(DAF::IllegalArgumentException);
         }
 

--- a/TAF/examples/CORBAExample/CORBAClient.cpp
+++ b/TAF/examples/CORBAExample/CORBAClient.cpp
@@ -94,7 +94,7 @@ static taf_xmpl::SimpleServer_ptr locate_SimpleServer(::CORBA::ORB_ptr orb)
             throw CORBA::TRANSIENT();
         } else break;
     } catch (const CORBA::Exception&) {
-        ACE_DEBUG((LM_ERROR, "CLIENT: SimpleServer Object reference is invalid - Retry(%d).\n",retry++)); ACE_OS::sleep(2);
+        ACE_DEBUG((LM_ERROR, "CLIENT: SimpleServer Object reference is invalid - Retry(%d).\n",retry++)); DAF_OS::sleep(2);
     }
 
     return objRef._retn();
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
                 server_objRef = taf_xmpl::SimpleServer::_nil();
             }
 
-            ACE_OS::sleep(1);
+            DAF_OS::sleep(1);
         }
     } catch (const CORBA::Exception& ex) {
         ex._tao_print_exception ("CLIENT: UNEXPECTED exception caught - "); return -1;

--- a/TAF/examples/CORBAExample/CORBAClientService.cpp
+++ b/TAF/examples/CORBAExample/CORBAClientService.cpp
@@ -131,7 +131,7 @@ namespace //anonymous
                 }
             } catch (const CORBA::Exception& ) {
                 ACE_DEBUG((LM_ERROR, "CLIENT SVC: SimpleServer Object reference is invalid - Retry(%d).\n", i));
-                ACE_OS::sleep(2);
+                DAF_OS::sleep(2);
             }
 
             ACE_DEBUG((LM_INFO, "\n\t*****CLIENT SERVICE (%04t) %T*****\n"));
@@ -147,7 +147,7 @@ namespace //anonymous
                 server = taf_xmpl::SimpleServer::_nil();
             }
 
-            ACE_OS::sleep(2);
+            DAF_OS::sleep(2);
         }
 
         return 0;

--- a/TAF/examples/CORBAExample/CORBAService.h
+++ b/TAF/examples/CORBAExample/CORBAService.h
@@ -73,9 +73,9 @@ namespace TAF_XMPL
         /// Initializes object when dynamic linking occurs.
         virtual int init(int argc, ACE_TCHAR *argv[]);
 
-        virtual int suspend(void)   { ACE_OS::last_error(ENOTSUP); return -1; }
+        virtual int suspend(void)   { DAF_OS::last_error(ENOTSUP); return -1; }
 
-        virtual int resume(void)    { ACE_OS::last_error(ENOTSUP); return -1; }
+        virtual int resume(void)    { DAF_OS::last_error(ENOTSUP); return -1; }
 
         /// Terminates object when dynamic unlinking occurs.
         virtual int fini(void);

--- a/TAF/examples/TextParser/TextParserClient.cpp
+++ b/TAF/examples/TextParser/TextParserClient.cpp
@@ -60,7 +60,7 @@ namespace {
 
         case 'c':
             for (const ACE_TCHAR *max_columns = get_opts.opt_arg(); max_columns;) {
-                _max_columns = unsigned(ace_range(1, 10, ACE_OS::atoi(max_columns))); break;
+                _max_columns = unsigned(ace_range(1, 10, DAF_OS::atoi(max_columns))); break;
             } break;
 
         case 'f':
@@ -68,18 +68,18 @@ namespace {
 
         case 'w':
             for (const ACE_TCHAR *loop_delay = get_opts.opt_arg(); loop_delay;) {
-                _loop_delay = unsigned(ace_range(1, 30, ACE_OS::atoi(loop_delay))); break;
+                _loop_delay = unsigned(ace_range(1, 30, DAF_OS::atoi(loop_delay))); break;
             } break;
 
         case 'n': _use_naming = true;
             for (const ACE_TCHAR *naming = get_opts.opt_arg(); naming;) {
-                _use_naming = (ace_range(0, 1, ACE_OS::atoi(naming)) ? true : false); break;
+                _use_naming = (ace_range(0, 1, DAF_OS::atoi(naming)) ? true : false); break;
             } break; // Turn on Naming optionally.
 
         case 'z': _debug = 1;
             for (const ACE_TCHAR *debug_lvl = get_opts.opt_arg(); debug_lvl;) {
                 if (::isdigit(int(*debug_lvl))) {
-                    _debug = ace_range(1, 10, ACE_OS::atoi(debug_lvl));
+                    _debug = ace_range(1, 10, DAF_OS::atoi(debug_lvl));
                 } break;
             } break; // Turn on Debug optionally at a level
 
@@ -102,7 +102,7 @@ namespace {
     {
         static size_t retry(1);
 
-        for (taf_xmpl::TextParser_var objRef; !_shutdown; ACE_OS::sleep(2)) {
+        for (taf_xmpl::TextParser_var objRef; !_shutdown; DAF_OS::sleep(2)) {
             try {
                 CORBA::Object_var server_proxy;
                 do {
@@ -167,7 +167,7 @@ namespace {
     CORBA::Boolean
     AlphabeticalPredicate_impl::callback_op(const taf_xmpl::WORDType &l, const taf_xmpl::WORDType &r)
     {
-        callbacks_++; return ACE_OS::strcmp(r.word_, l.word_) > 0 ? this->ascending_ : !this->ascending_;
+        callbacks_++; return DAF_OS::strcmp(r.word_, l.word_) > 0 ? this->ascending_ : !this->ascending_;
     }
 
     typedef TAF::ObjectStubRef<AlphabeticalPredicate_impl>  AlphabeticalPredicateStub_ref;
@@ -186,11 +186,11 @@ namespace {
     WordLengthPredicate_impl::callback_op(const taf_xmpl::WORDType &l, const taf_xmpl::WORDType &r)
     {
         callbacks_++;
-        int r_len = int(r.word_ ? ACE_OS::strlen(r.word_) : 0U);
-        int l_len = int(l.word_ ? ACE_OS::strlen(l.word_) : 0U);
+        int r_len = int(r.word_ ? DAF_OS::strlen(r.word_) : 0U);
+        int l_len = int(l.word_ ? DAF_OS::strlen(l.word_) : 0U);
         if (r_len == l_len) {
             if (r.count_ == l.count_) {
-                return ACE_OS::strcmp(r.word_, l.word_) > 0 ? this->ascending_ : !this->ascending_;
+                return DAF_OS::strcmp(r.word_, l.word_) > 0 ? this->ascending_ : !this->ascending_;
             }
             return (r.count_ > l.count_) ? this->ascending_ : !this->ascending_;
         }
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
 
         size_t iov_len = read_textfile(_TXT_FILENAME, io_buff.out());
 
-        if (iov_len == size_t(-1) || ACE_OS::strlen(io_buff.in()) != iov_len) {
+        if (iov_len == size_t(-1) || DAF_OS::strlen(io_buff.in()) != iov_len) {
             return -1;
         }
 
@@ -247,7 +247,7 @@ int main(int argc, char *argv[])
                     case 0: ascending = false;
                     case 1:
                         {
-                            ACE_OS::sprintf(timerMsg, ACE_TEXT("\n%04d - TextClient->InstanceRequest - Instance %s :")
+                            DAF_OS::sprintf(timerMsg, ACE_TEXT("\n%04d - TextClient->InstanceRequest - Instance %s :")
                                 , j, (ascending ? "Ascending" : "Decending"));
                             {
                                 DAF::HighResTimer _(timerMsg);
@@ -260,7 +260,7 @@ int main(int argc, char *argv[])
                         {
                             const AlphabeticalPredicateStub_ref predicate(new AlphabeticalPredicate_impl(ascending));
 
-                            ACE_OS::sprintf(timerMsg, ACE_TEXT("\n%04d - TextClient->PredicateRequest - Alphabetical %s :")
+                            DAF_OS::sprintf(timerMsg, ACE_TEXT("\n%04d - TextClient->PredicateRequest - Alphabetical %s :")
                                 , j, (ascending ? "Ascending" : "Decending"));
                             {
                                 DAF::HighResTimer _(timerMsg);
@@ -278,7 +278,7 @@ int main(int argc, char *argv[])
                         {
                             const WordLengthPredicateStub_ref predicate(new WordLengthPredicate_impl(ascending));
 
-                            ACE_OS::sprintf(timerMsg, ACE_TEXT("\n%04d - TextClient->PredicateRequest - WordLength %s :")
+                            DAF_OS::sprintf(timerMsg, ACE_TEXT("\n%04d - TextClient->PredicateRequest - WordLength %s :")
                                 , j, (ascending ? "Ascending" : "Decending"));
                             {
                                 DAF::HighResTimer _(timerMsg);
@@ -322,7 +322,7 @@ int main(int argc, char *argv[])
                 server_objRef = taf_xmpl::TextParser::_nil();
             }
 
-            ACE_OS::sleep(_loop_delay);
+            DAF_OS::sleep(_loop_delay);
         }
     } catch (const CORBA::Exception& ex) {
         ex._tao_print_exception ("TextParser CLIENT: UNEXPECTED exception caught - "); return -1;

--- a/TAF/examples/TextParser/TextParserService.cpp
+++ b/TAF/examples/TextParser/TextParserService.cpp
@@ -58,7 +58,7 @@ namespace  // Ananomous namespace
     public:
         AlphabeticalPredicate(bool ascending) : ascending_(ascending) {}
         bool operator () (const first_argument_type &l, const second_argument_type &r) const {
-            return ACE_OS::strcmp(r.word_, l.word_) > 0 ? this->ascending_ : !this->ascending_;
+            return DAF_OS::strcmp(r.word_, l.word_) > 0 ? this->ascending_ : !this->ascending_;
         }
     };
 
@@ -100,7 +100,7 @@ namespace  // Ananomous namespace
     {
         wordlist.clear();
 
-        if (text ? ACE_OS::strlen(text) == 0 : true) {
+        if (text ? DAF_OS::strlen(text) == 0 : true) {
             throw CORBA::BAD_PARAM();
         }
 
@@ -197,17 +197,17 @@ namespace TAF_XMPL
         case -1: return 0; // Indicates sucessful parsing of the command line
 
         case 'n': this->use_naming_ = true; for (const ACE_TCHAR *naming = get_opts.opt_arg(); naming;) {
-            this->use_naming_ = (ace_range(0, 1, ACE_OS::atoi(naming)) ? true : false); break;
+            this->use_naming_ = (ace_range(0, 1, DAF_OS::atoi(naming)) ? true : false); break;
         } break; // Turn on Naming optionally.
 
         case 'o': for (const ACE_TCHAR * iorFile = get_opts.opt_arg(); iorFile;) {
-            if (ACE_OS::strlen(iorFile) > 0) { this->ior_file_.assign(iorFile); } break;
+            if (DAF_OS::strlen(iorFile) > 0) { this->ior_file_.assign(iorFile); } break;
         } break; // Turn on IOR File write.
 
         case 'z': this->debug_ = 1;
             for (const ACE_TCHAR *debug_lvl = get_opts.opt_arg(); debug_lvl;) {
                 if (::isdigit(int(*debug_lvl))) {
-                    this->debug_ = ace_range(0, 10, ACE_OS::atoi(debug_lvl));
+                    this->debug_ = ace_range(0, 10, DAF_OS::atoi(debug_lvl));
                 } break;
             } break; // Turn on Debug at level optionally.
 
@@ -257,13 +257,13 @@ namespace TAF_XMPL
     int
     TextParserService::suspend(void)
     {
-        ACE_OS::last_error(ENOTSUP); return -1;
+        DAF_OS::last_error(ENOTSUP); return -1;
     }
 
     int
     TextParserService::resume(void)
     {
-        ACE_OS::last_error(ENOTSUP); return -1;
+        DAF_OS::last_error(ENOTSUP); return -1;
     }
 
     /// Terminates object when dynamic unlinking occurs.

--- a/TAF/idl/tests/mpc_idl_project/TestMain.cpp
+++ b/TAF/idl/tests/mpc_idl_project/TestMain.cpp
@@ -127,8 +127,8 @@ int ACE_TMAIN (int argc, char *argv [])
 
   for (int i = 0 ;i < num_of_messages; ++i ) try
   {
-    dsto::DRAWDetails_TopicType dt = { ::dsto::Triangle, i, CORBA::ULongLong(ACE_OS::gethrtime(ACE_OS::ACE_HRTIMER_GETTIME)) }; writer << dt;
-    ACE_OS::sleep(ACE_Time_Value(0, 100000));
+    dsto::DRAWDetails_TopicType dt = { ::dsto::Triangle, i, CORBA::ULongLong(DAF_OS::gethrtime(DAF_OS::ACE_HRTIMER_GETTIME)) }; writer << dt;
+    DAF_OS::sleep(ACE_Time_Value(0, 100000));
   }
   catch(...)
   {

--- a/TAF/orbsvcs/NamingService/NamingService.cpp
+++ b/TAF/orbsvcs/NamingService/NamingService.cpp
@@ -162,13 +162,13 @@ namespace TAF
     int
     NamingService::suspend(void)
     {
-        ACE_OS::last_error(ENOTSUP); return -1;
+        DAF_OS::last_error(ENOTSUP); return -1;
     }
 
     int
     NamingService::resume(void)
     {
-        ACE_OS::last_error(ENOTSUP); return -1;
+        DAF_OS::last_error(ENOTSUP); return -1;
     }
 
     int

--- a/TAF/taf/CDRStream.cpp
+++ b/TAF/taf/CDRStream.cpp
@@ -28,13 +28,13 @@ namespace TAF
     OutputCDR::OutputCDR(size_t size, int byte_order)
         : TAO_OutputCDR(size, byte_order)
     {
-        ACE_OS::memset(this->current()->wr_ptr(),0,this->current()->space());
+        DAF_OS::memset(this->current()->wr_ptr(),0,this->current()->space());
     }
 
     OutputCDR::OutputCDR(char *data, size_t size, int byte_order)
         : TAO_OutputCDR(data, size, byte_order)
     {
-        ACE_OS::memset(this->current()->wr_ptr(),0,this->current()->space());
+        DAF_OS::memset(this->current()->wr_ptr(),0,this->current()->space());
     }
 
     size_t

--- a/TAF/taf/GestaltService_impl.cpp
+++ b/TAF/taf/GestaltService_impl.cpp
@@ -159,7 +159,7 @@ namespace TAF
     taf::EntityDescriptor *
     GestaltService_impl::findService(const char *svc_ident)
     {
-        if (svc_ident && ACE_OS::strlen(svc_ident) > 0) do {
+        if (svc_ident && DAF_OS::strlen(svc_ident) > 0) do {
             ACE_READ_GUARD_REACTION(ACE_SYNCH_RW_MUTEX, taf_mon, this->lock_, throw CORBA::BAD_OPERATION()); // Stop re-entrancy
             return this->makeEntityDescriptor(svc_ident)._retn();
         } while (false);
@@ -197,7 +197,7 @@ namespace TAF
     CORBA::Long
     GestaltService_impl::loadConfigFile(const char *profile_arg, CORBA::Long_out count)
     {
-        if (profile_arg && ACE_OS::strlen(profile_arg) > 0) try {
+        if (profile_arg && DAF_OS::strlen(profile_arg) > 0) try {
             GestaltServiceLoader svcLoader(*this);
             if (svcLoader.load_file_profile(DAF::trim_string(profile_arg)) == 0) {
                 count = CORBA::Long(svcLoader.size()); return CORBA::Long(svcLoader.process_directives());
@@ -212,7 +212,7 @@ namespace TAF
     void
     GestaltService_impl::loadStatic(const char *ident, const char *parameters)
     {
-        if (ident && ACE_OS::strlen(ident)) do {
+        if (ident && DAF_OS::strlen(ident)) do {
 
             const std::string svc_ident(DAF::trim_string(ident));
 
@@ -233,7 +233,7 @@ namespace TAF
                 const ACE_Service_Type *svc_type = 0;
 
                 if (this->find(svc_ident.c_str(), &svc_type, false) == 0) {
-                    ACE_OS::last_error(EEXIST); break;
+                    DAF_OS::last_error(EEXIST); break;
                 }
 
                 if (this->process_command(command, DEFAULT_SLOAD_TIMEOUT)) {
@@ -254,7 +254,7 @@ namespace TAF
                     , svc_ident.c_str(), DAF::last_error_text().c_str()));
             }
 
-            switch (ACE_OS::last_error()) {
+            switch (DAF_OS::last_error()) {
             case ETIME: throw CORBA::TIMEOUT();
             default:    throw CORBA::BAD_OPERATION();
             }
@@ -267,7 +267,7 @@ namespace TAF
     void
     GestaltService_impl::loadDynamic(const char *ident, const char *libpathname, const char *objectclass, const char *parameters)
     {
-        if (ident && ACE_OS::strlen(ident)) do {
+        if (ident && DAF_OS::strlen(ident)) do {
 
             const std::string svc_ident(DAF::trim_string(ident));
 
@@ -318,7 +318,7 @@ namespace TAF
                 const ACE_Service_Type *svc_type = 0;
 
                 if (this->find(svc_ident.c_str(), &svc_type, false) == 0) {
-                    ACE_OS::last_error(EEXIST); break;
+                    DAF_OS::last_error(EEXIST); break;
                 }
 
                 if (this->process_command(command, DEFAULT_DLOAD_TIMEOUT)) {
@@ -338,7 +338,7 @@ namespace TAF
                     , svc_ident.c_str(), DAF::last_error_text().c_str()));
             }
 
-            switch (ACE_OS::last_error()) {
+            switch (DAF_OS::last_error()) {
             case ETIME: throw CORBA::TIMEOUT();
             default:    throw CORBA::BAD_OPERATION();
             }
@@ -351,7 +351,7 @@ namespace TAF
     void
     GestaltService_impl::suspend(const char *ident)
     {
-        if (ident && ACE_OS::strlen(ident)) do {
+        if (ident && DAF_OS::strlen(ident)) do {
 
             const std::string svc_ident(DAF::trim_string(ident));
 
@@ -368,17 +368,17 @@ namespace TAF
                 const ACE_Service_Type *svc_type = 0;
 
                 if (this->find(svc_ident.c_str(), &svc_type, false) || svc_type == 0) {
-                    ACE_OS::last_error(EEXIST); break;
+                    DAF_OS::last_error(EEXIST); break;
                 }
 
                 if (svc_type->fini_called()) {
-                    ACE_OS::last_error(EACCES); break;
+                    DAF_OS::last_error(EACCES); break;
                 }
 
                 if (svc_type->active() ? this->process_command(command, DEFAULT_SUSPEND_TIMEOUT) : 0) {
                     const_cast<ACE_Service_Type*>(svc_type)->active(true); // Set back to active
-                    switch (ACE_OS::last_error()) {
-                    case EINVAL: ACE_OS::last_error(ENOTSUP); // Gestalt sets EINVAL when -1 returned
+                    switch (DAF_OS::last_error()) {
+                    case EINVAL: DAF_OS::last_error(ENOTSUP); // Gestalt sets EINVAL when -1 returned
                     default: continue;
                     }
                 }
@@ -397,7 +397,7 @@ namespace TAF
                     , svc_ident.c_str(), DAF::last_error_text().c_str()));
             }
 
-            switch (ACE_OS::last_error()) {
+            switch (DAF_OS::last_error()) {
             case ENOTSUP:   throw CORBA::NO_IMPLEMENT();
             case ETIME:     throw CORBA::TIMEOUT();
             default:        throw CORBA::BAD_OPERATION();
@@ -411,7 +411,7 @@ namespace TAF
     void
     GestaltService_impl::resume(const char *ident)
     {
-        if (ident && ACE_OS::strlen(ident)) do {
+        if (ident && DAF_OS::strlen(ident)) do {
 
             const std::string svc_ident(DAF::trim_string(ident));
 
@@ -428,17 +428,17 @@ namespace TAF
                 const ACE_Service_Type *svc_type = 0;
 
                 if (this->find(svc_ident.c_str(), &svc_type, false) || svc_type == 0) {
-                    ACE_OS::last_error(EEXIST); break;
+                    DAF_OS::last_error(EEXIST); break;
                 }
 
                 if (svc_type->fini_called()) {
-                    ACE_OS::last_error(EACCES); break;
+                    DAF_OS::last_error(EACCES); break;
                 }
 
                 if (svc_type->active() ? 0 : this->process_command(command, DEFAULT_RESUME_TIMEOUT)) {
                     const_cast<ACE_Service_Type*>(svc_type)->active(false);  // Set back to in-active
-                    switch (ACE_OS::last_error()) {
-                    case EINVAL: ACE_OS::last_error(ENOTSUP); // Gestalt sets EINVAL when -1 returned
+                    switch (DAF_OS::last_error()) {
+                    case EINVAL: DAF_OS::last_error(ENOTSUP); // Gestalt sets EINVAL when -1 returned
                     default: continue;
                     }
                 }
@@ -457,7 +457,7 @@ namespace TAF
                     , svc_ident.c_str(), DAF::last_error_text().c_str()));
             }
 
-            switch (ACE_OS::last_error()) {
+            switch (DAF_OS::last_error()) {
             case ENOTSUP:   throw CORBA::NO_IMPLEMENT();
             case ETIME:     throw CORBA::TIMEOUT();
             default:        throw CORBA::BAD_OPERATION();
@@ -471,7 +471,7 @@ namespace TAF
     void
     GestaltService_impl::remove(const char *ident)
     {
-        if (ident && ACE_OS::strlen(ident)) do {
+        if (ident && DAF_OS::strlen(ident)) do {
 
             const std::string svc_ident(DAF::trim_string(ident));
 
@@ -493,7 +493,7 @@ namespace TAF
                 const ACE_Service_Type *svc_type = 0;
 
                 if (this->find(svc_ident.c_str(), &svc_type, false) || svc_type == 0) {
-                    ACE_OS::last_error(EEXIST); break;
+                    DAF_OS::last_error(EEXIST); break;
                 }
 
                 if (svc_type->fini_called() ? 0 : this->process_command(command, DEFAULT_REMOVE_TIMEOUT)) {
@@ -514,7 +514,7 @@ namespace TAF
                     , svc_ident.c_str(), DAF::last_error_text().c_str()));
             }
 
-            switch (ACE_OS::last_error()) {
+            switch (DAF_OS::last_error()) {
             case ETIME: throw CORBA::TIMEOUT();
             default:    throw CORBA::BAD_OPERATION();
             }

--- a/TAF/taf/ORBManager.cpp
+++ b/TAF/taf/ORBManager.cpp
@@ -176,7 +176,7 @@ namespace TAF {
                     ACE_TEXT("ERROR: Failed to initialize %d threads for %s instance.\n")
                     , orb_threads, tafORBName()), -1);
             }
-            ACE_OS::thr_yield(); // Yield a little for threads to start
+            DAF_OS::thr_yield(); // Yield a little for threads to start
         }
 
         return 0;

--- a/TAF/taf/PropertyLoader.cpp
+++ b/TAF/taf/PropertyLoader.cpp
@@ -79,7 +79,7 @@ namespace TAF
 
         if (this->load_count() ? false : use_env) {
 
-            for (const char *properties = ACE_OS::getenv(this->config_switch()); properties;) {
+            for (const char *properties = DAF_OS::getenv(this->config_switch()); properties;) {
                 try {
                     if (this->load_file_profile(properties) == 0) {
                         break;

--- a/TAF/taf/PropertyServer_impl.cpp
+++ b/TAF/taf/PropertyServer_impl.cpp
@@ -29,7 +29,7 @@ namespace TAF
     char *
     PropertyServer_impl::get_property(const char *ident)
     {
-        if (ident && ACE_OS::strlen(ident) > 0) try {
+        if (ident && DAF_OS::strlen(ident) > 0) try {
             return CORBA::string_dup(ThePropertyRepository()->get_property(ident, true).c_str());
         } catch (const DAF::NotFoundException&) {
         } catch (const DAF::IllegalArgumentException&) {
@@ -46,7 +46,7 @@ namespace TAF
     void
     PropertyServer_impl::set_property(const char *ident, const char *value)
     {
-        if (ident && ACE_OS::strlen(ident) > 0) try {
+        if (ident && DAF_OS::strlen(ident) > 0) try {
             if (ThePropertyRepository()->set_property(ident, (value ? value : "")) == 0) {
                 return;
             }
@@ -63,7 +63,7 @@ namespace TAF
     void
     PropertyServer_impl::del_property(const char *ident)
     {
-        if (ident && ACE_OS::strlen(ident) > 0) try {
+        if (ident && DAF_OS::strlen(ident) > 0) try {
             ThePropertyRepository()->del_property(ident); return;
         } catch (const DAF::IllegalThreadStateException&) {
             throw CORBA::BAD_OPERATION();

--- a/TAF/taf/StringManager_T.h
+++ b/TAF/taf/StringManager_T.h
@@ -99,7 +99,7 @@ namespace TAF
 template <typename T>
 inline bool operator <  (const TAF::StringManager_T<T> &lhs, const TAF::StringManager_T<T> &rhs)
 {
-    return ACE_OS::strcmp(lhs.in(), rhs.in()) < 0;
+    return DAF_OS::strcmp(lhs.in(), rhs.in()) < 0;
 }
 
 #endif // TAF_STRINGMANAGER_T_H

--- a/TAF/taf/TAFDebug.cpp
+++ b/TAF/taf/TAFDebug.cpp
@@ -29,10 +29,10 @@ namespace {
     void    taf_print_debug(const char *id, int dbug)
     {
         char s[32]; if (dbug) {
-            ACE_OS::sprintf(s, ACE_TEXT("ON[%d]"), dbug);
+            DAF_OS::sprintf(s, ACE_TEXT("ON[%d]"), dbug);
         }
         else {
-            ACE_OS::strcpy(s, ACE_TEXT("OFF"));
+            DAF_OS::strcpy(s, ACE_TEXT("OFF"));
         }
         ACE_DEBUG((LM_INFO, ACE_TEXT("%s=%s - %T\n"), (id ? id : "Debug"), s));
     }

--- a/TAF/taf/TAFServer_impl.cpp
+++ b/TAF/taf/TAFServer_impl.cpp
@@ -147,7 +147,7 @@ namespace TAF
     void
     TAFServer_impl::sendConsoleMsg(const char *msg)
     {
-        if (msg && ACE_OS::strlen(msg) > 0) {
+        if (msg && DAF_OS::strlen(msg) > 0) {
             ACE_DEBUG((LM_INFO, ACE_TEXT("\nINFO: %s[%s @ %D]\n'%s'\n")
                 , TAFServerImpl::svc_ident()
                 , tafServerName()
@@ -240,13 +240,13 @@ namespace TAF
     int
     TAFServer_impl::suspend(void)
     {
-        ACE_OS::last_error(ENOTSUP); return -1;
+        DAF_OS::last_error(ENOTSUP); return -1;
     }
 
     int
     TAFServer_impl::resume(void)
     {
-        ACE_OS::last_error(ENOTSUP); return -1;
+        DAF_OS::last_error(ENOTSUP); return -1;
     }
 
     int
@@ -400,7 +400,7 @@ namespace {
 
         if (ACE_Service_Config::process_directive(TAFServerDescriptor, false) == 0) {
             if (ACE_Service_Config::initialize(TAFServer::svc_ident(), args.c_str()) == 0) {
-                ACE_OS::thr_yield(); return; // Allow a little for TAFServer to load-up
+                DAF_OS::thr_yield(); return; // Allow a little for TAFServer to load-up
             }
         }
 
@@ -448,7 +448,7 @@ namespace {
         try {
             ACE_Service_Config_Guard svc_guard(ACE_Service_Config::global()); ACE_UNUSED_ARG(svc_guard);
             for (TAFServer * tafServer(ACE_Dynamic_Service<TAFServer>::instance(TAFServer::svc_ident())); tafServer;) {
-                this->initResult_ = 0; this->initLock_.release(); ACE_OS::thr_yield(); // Let the wait_result() waiter go
+                this->initResult_ = 0; this->initLock_.release(); DAF_OS::thr_yield(); // Let the wait_result() waiter go
                 {
                     const DAF::ShutdownHandler shutdown_handler; return tafServer->run(true);  ACE_UNUSED_ARG(shutdown_handler);
                 }
@@ -474,10 +474,10 @@ extern "C" {
         static time_t tafserver_loader_timeout_(TAFServer::TAFSERVER_LOAD_TIMEOUT); // Timeout in Seconds
 
         static struct TAFServerLoaderTimeout {
-            TAFServerLoaderTimeout(const char *_tafserver_load_timeout = ACE_OS::getenv(TAF_SERVERLOADTIMEOUT)) {
+            TAFServerLoaderTimeout(const char *_tafserver_load_timeout = DAF_OS::getenv(TAF_SERVERLOADTIMEOUT)) {
                 if (_tafserver_load_timeout) {
                     const std::string tm(DAF::trim_string(_tafserver_load_timeout)); if (tm.length() && ::isdigit(int(tm[0]))) {
-                        tafserver_loader_timeout_ = time_t(ace_range(30, 300, ACE_OS::atoi(tm.c_str())));
+                        tafserver_loader_timeout_ = time_t(ace_range(30, 300, DAF_OS::atoi(tm.c_str())));
                     }
                 }
             }

--- a/TAF/taf/extensions/discovery/DiscoveryHandler.cpp
+++ b/TAF/taf/extensions/discovery/DiscoveryHandler.cpp
@@ -185,7 +185,7 @@ namespace TAF
     DiscoveryHandler::open_handler(const ACE_INET_Addr &mcast_addr, const char *net_if, bool reuse_addr)
     {
         do {
-            if (net_if && ACE_OS::strlen(net_if) > 0) {
+            if (net_if && DAF_OS::strlen(net_if) > 0) {
                 if (ACE_SOCK_Dgram_Mcast::join(mcast_addr, reuse_addr, net_if) == 0) {
                     break;
                 }
@@ -212,7 +212,7 @@ namespace TAF
     int
     DiscoveryHandler::sendIORQuery(const IORQueryReplyHandler &rh, const ACE_TCHAR *svc_ident)
     {
-        if (svc_ident && ACE_OS::strlen(svc_ident) > 0) {
+        if (svc_ident && DAF_OS::strlen(svc_ident) > 0) {
 
             const taf::IORQuery mcast_query = {
                 CORBA::UShort(rh.getReplyPort()), CORBA::UShort(0), svc_ident

--- a/TAF/taf/extensions/discovery/DiscoveryService.cpp
+++ b/TAF/taf/extensions/discovery/DiscoveryService.cpp
@@ -112,7 +112,7 @@ namespace TAF
 
                     for (ACE_SOCK_Dgram dgram; dgram.open(ACE_Addr::sap_any) != -1;) {
 
-                        ACE_OS::sleep(ACE_Time_Value(0, suseconds_t(DAF_OS::rand(500, 5000))));  // Stagger replies
+                        DAF_OS::sleep(ACE_Time_Value(0, suseconds_t(DAF_OS::rand(500, 5000))));  // Stagger replies
 
                         const ACE_Time_Value send_timeout(3);
 

--- a/TAF/tests/StringManagerTest/StringManagerTest.cpp
+++ b/TAF/tests/StringManagerTest/StringManagerTest.cpp
@@ -95,7 +95,7 @@ namespace {
 
     int validate_string_var_type(const CORBA::String_var &s)
     {
-        return ACE_OS::strcmp(s, DEREK_TEXT) == 0;
+        return DAF_OS::strcmp(s, DEREK_TEXT) == 0;
     }
 
     int validate_string_vector_type(const StringVectorType &s)
@@ -103,7 +103,7 @@ namespace {
         if (s.size() == MAX_SEQUENCE_SIZE) {
             for (size_t i = 0; i < MAX_SEQUENCE_SIZE; i++) {
                 std::stringstream ss; std::ends(ss << DEREK_TEXT << int(i));
-                if (ACE_OS::strcmp(ss.str().c_str(), s[i].in())) return false;
+                if (DAF_OS::strcmp(ss.str().c_str(), s[i].in())) return false;
             }
             return true;
         }
@@ -115,7 +115,7 @@ namespace {
         if (s.length() == CORBA::ULong(MAX_SEQUENCE_SIZE)) {
             for (CORBA::ULong i = 0; i < CORBA::ULong(MAX_SEQUENCE_SIZE); i++) {
                 std::stringstream ss; std::ends(ss << DEREK_TEXT << int(i));
-                if (ACE_OS::strcmp(ss.str().c_str(), s[i].in())) return false;
+                if (DAF_OS::strcmp(ss.str().c_str(), s[i].in())) return false;
             }
             return true;
         }

--- a/TAF/tests/TestUtilService/TestService.cpp
+++ b/TAF/tests/TestUtilService/TestService.cpp
@@ -209,7 +209,7 @@ namespace test
             case 'h': print_usage(); return -1;
             case 's': this->shutdown_ = true; break;
             case 'z': this->debug_ = 1; break;
-            case 't': this->timer_ = ACE_Time_Value(ACE_OS::atoi(cli_opt.opt_arg()));
+            case 't': this->timer_ = ACE_Time_Value(DAF_OS::atoi(cli_opt.opt_arg()));
                       break;
         }
 

--- a/TAF/tests/VectorSequenceTest/VectorSequenceTest.cpp
+++ b/TAF/tests/VectorSequenceTest/VectorSequenceTest.cpp
@@ -80,11 +80,11 @@ namespace {
         for (CORBA::ULong i = 0; i < t->maximum(); i++) {
             t->length(i + 1); char s[16];
             {
-                ACE_OS::sprintf(s, ACE_TEXT("%04d"), int(i));
+                DAF_OS::sprintf(s, ACE_TEXT("%04d"), int(i));
                 t[i].s1 = std::string(s).c_str();
             }
             {
-                ACE_OS::sprintf(s, ACE_TEXT("%04d"), int(i * 100));
+                DAF_OS::sprintf(s, ACE_TEXT("%04d"), int(i * 100));
                 t[i].s2 = std::string(s).c_str();
             }
         }
@@ -117,13 +117,13 @@ namespace {
             for (size_t i = 0; i < MAX_SEQUENCE_SIZE; i++) {
                 char s[16];
                 {
-                    ACE_OS::sprintf(s, ACE_TEXT("%04d"), int(i));
+                    DAF_OS::sprintf(s, ACE_TEXT("%04d"), int(i));
                     if (std::string(s) != v[i].s1.in()) {
                         return false;
                     }
                 }
                 {
-                    ACE_OS::sprintf(s, ACE_TEXT("%04d"), int(i * 100));
+                    DAF_OS::sprintf(s, ACE_TEXT("%04d"), int(i * 100));
                     if (std::string(s) != v[i].s2.in()) {
                         return false;
                     }
@@ -166,13 +166,13 @@ namespace {
             for (CORBA::ULong i = 0; i < t.length(); i++) {
                 char s[16];
                 {
-                    ACE_OS::sprintf(s, ACE_TEXT("%04d"), int(i));
+                    DAF_OS::sprintf(s, ACE_TEXT("%04d"), int(i));
                     if (std::string(s) != t[i].s1.in()) {
                         return false;
                     }
                 }
                 {
-                    ACE_OS::sprintf(s, ACE_TEXT("%04d"), int(i * 100));
+                    DAF_OS::sprintf(s, ACE_TEXT("%04d"), int(i * 100));
                     if (std::string(s) != t[i].s2.in()) {
                         return false;
                     }

--- a/TTY_Asynch/TTY_Device.cpp
+++ b/TTY_Asynch/TTY_Device.cpp
@@ -238,24 +238,24 @@ namespace DEV
 
             if (param_arg.length() == 0 || param_val.length() == 0) {
                 continue;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "baud") == 0) {  // Defaults to 9600
-                int baudrate = ACE_OS::atoi(param_val.c_str()); if (baudrate > 0) {
-                    this->tty_params.baudrate = ace_range(50, 256000, ACE_OS::atoi(param_val.c_str()));
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "baud") == 0) {  // Defaults to 9600
+                int baudrate = DAF_OS::atoi(param_val.c_str()); if (baudrate > 0) {
+                    this->tty_params.baudrate = ace_range(50, 256000, DAF_OS::atoi(param_val.c_str()));
                 } else this->tty_params.baudrate = 9600;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "parity") == 0) {  // Defaults to ACE_TTY_IO_NONE
-                if        (param_val[0] == '1' || param_val == "O" || ACE_OS::strcasecmp(param_val.c_str(), TTY_PARITY_STR[TTY_PARITY_ODD])     == 0) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "parity") == 0) {  // Defaults to ACE_TTY_IO_NONE
+                if        (param_val[0] == '1' || param_val == "O" || DAF_OS::strcasecmp(param_val.c_str(), TTY_PARITY_STR[TTY_PARITY_ODD])     == 0) {
                     this->tty_params.paritymode = TTY_PARITY_STR[TTY_PARITY_ODD];
-                } else if (param_val[0] == '2' || param_val == "E" || ACE_OS::strcasecmp(param_val.c_str(), TTY_PARITY_STR[TTY_PARITY_EVEN])    == 0) {
+                } else if (param_val[0] == '2' || param_val == "E" || DAF_OS::strcasecmp(param_val.c_str(), TTY_PARITY_STR[TTY_PARITY_EVEN])    == 0) {
                     this->tty_params.paritymode = TTY_PARITY_STR[TTY_PARITY_EVEN];
 #if defined(ACE_WIN32)
-                } else if (param_val[0] == '3' || param_val == "M" || ACE_OS::strcasecmp(param_val.c_str(), TTY_PARITY_STR[TTY_PARITY_MARK])    == 0) {
+                } else if (param_val[0] == '3' || param_val == "M" || DAF_OS::strcasecmp(param_val.c_str(), TTY_PARITY_STR[TTY_PARITY_MARK])    == 0) {
                     this->tty_params.paritymode = TTY_PARITY_STR[TTY_PARITY_MARK];
-                } else if (param_val[0] == '4' || param_val == "S" || ACE_OS::strcasecmp(param_val.c_str(), TTY_PARITY_STR[TTY_PARITY_SPACE])   == 0) {
+                } else if (param_val[0] == '4' || param_val == "S" || DAF_OS::strcasecmp(param_val.c_str(), TTY_PARITY_STR[TTY_PARITY_SPACE])   == 0) {
                     this->tty_params.paritymode = TTY_PARITY_STR[TTY_PARITY_SPACE];
 #endif
                 } else this->tty_params.paritymode = TTY_PARITY_STR[TTY_PARITY_NONE];
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "data") == 0) {  // Defaults to 8
-                int databits = ACE_OS::atoi(param_val.c_str()); switch (databits) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "data") == 0) {  // Defaults to 8
+                int databits = DAF_OS::atoi(param_val.c_str()); switch (databits) {
                 default: databits = 8; // Otherwise Use 8
                 case 4 :
                 case 5 :
@@ -263,62 +263,62 @@ namespace DEV
                 case 7 :
                 case 8 : this->tty_params.databits = databits;
                 }
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "stop") == 0) {  // Defaults to 1
-                int stopbits = ACE_OS::atoi(param_val.c_str()); switch (stopbits) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "stop") == 0) {  // Defaults to 1
+                int stopbits = DAF_OS::atoi(param_val.c_str()); switch (stopbits) {
                 default: stopbits = 1; // Otherwise Use 1
                 case 1 :
                 case 2 : this->tty_params.stopbits = stopbits;
                 }
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "to") == 0) {
-                int readtimeoutmsec = ACE_OS::atoi(param_val.c_str()); if (readtimeoutmsec > 0) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "to") == 0) {
+                int readtimeoutmsec = DAF_OS::atoi(param_val.c_str()); if (readtimeoutmsec > 0) {
                     this->tty_params.readtimeoutmsec = readtimeoutmsec;
                 } else this->tty_params.readtimeoutmsec = 10000;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "xon") == 0) {
-                if (param_val[0] == '1' || ACE_OS::strcasecmp(param_val.c_str(), "on") == 0) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "xon") == 0) {
+                if (param_val[0] == '1' || DAF_OS::strcasecmp(param_val.c_str(), "on") == 0) {
                     this->tty_params.xinenb = this->tty_params.xoutenb = true;
                 } else this->tty_params.xinenb = this->tty_params.xoutenb = false;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "xin") == 0) {
-                if (param_val[0] == '1' || ACE_OS::strcasecmp(param_val.c_str(), "on") == 0) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "xin") == 0) {
+                if (param_val[0] == '1' || DAF_OS::strcasecmp(param_val.c_str(), "on") == 0) {
                     this->tty_params.xinenb = true;
                 } else this->tty_params.xinenb = false;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "xout") == 0) {
-                if (param_val[0] == '1' || ACE_OS::strcasecmp(param_val.c_str(), "on") == 0) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "xout") == 0) {
+                if (param_val[0] == '1' || DAF_OS::strcasecmp(param_val.c_str(), "on") == 0) {
                     this->tty_params.xoutenb = true;
                 } else this->tty_params.xoutenb = false;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "xonlim") == 0)    {
-                int xonlim = ACE_OS::atoi(param_val.c_str()); if (xonlim > 0)   {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "xonlim") == 0)    {
+                int xonlim = DAF_OS::atoi(param_val.c_str()); if (xonlim > 0)   {
                     this->tty_params.xonlim = xonlim;
                 } else this->tty_params.xonlim = 0;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "xofflim") == 0)   {
-                int xofflim = ACE_OS::atoi(param_val.c_str()); if (xofflim > 0) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "xofflim") == 0)   {
+                int xofflim = DAF_OS::atoi(param_val.c_str()); if (xofflim > 0) {
                     this->tty_params.xofflim = xofflim;
                 } else this->tty_params.xofflim = 0;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "odsr") == 0) { // Enable/disable DSR protocol.
-                if (param_val[0] == '1' || ACE_OS::strcasecmp(param_val.c_str(), "on") == 0) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "odsr") == 0) { // Enable/disable DSR protocol.
+                if (param_val[0] == '1' || DAF_OS::strcasecmp(param_val.c_str(), "on") == 0) {
                     this->tty_params.dsrenb = true;
                 } this->tty_params.dsrenb = false;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "octs") == 0) { // Enable/disable CTS protocol.
-                if (param_val[0] == '1' || ACE_OS::strcasecmp(param_val.c_str(), "on") == 0) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "octs") == 0) { // Enable/disable CTS protocol.
+                if (param_val[0] == '1' || DAF_OS::strcasecmp(param_val.c_str(), "on") == 0) {
                     this->tty_params.ctsenb = true;
                 } this->tty_params.ctsenb = false;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "dtr") == 0)  { // Disable/enable DTR protocol
-                if (param_val[0] == '1' || ACE_OS::strcasecmp(param_val.c_str(), "on") == 0) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "dtr") == 0)  { // Disable/enable DTR protocol
+                if (param_val[0] == '1' || DAF_OS::strcasecmp(param_val.c_str(), "on") == 0) {
                     this->tty_params.dtrdisable = true;
                 } this->tty_params.dtrdisable = false;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "rts") == 0)  {
-                if (param_val[0] == '1' || ACE_OS::strcasecmp(param_val.c_str(), "on") == 0) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "rts") == 0)  {
+                if (param_val[0] == '1' || DAF_OS::strcasecmp(param_val.c_str(), "on") == 0) {
                     this->tty_params.rtsenb = 1;
-                } else if (param_val[0] == '2' || ACE_OS::strcasecmp(param_val.c_str(), "hs") == 0) {
+                } else if (param_val[0] == '2' || DAF_OS::strcasecmp(param_val.c_str(), "hs") == 0) {
                     this->tty_params.rtsenb = 2;
-                } else if (param_val[0] == '3' || ACE_OS::strcasecmp(param_val.c_str(), "tg") == 0) {
+                } else if (param_val[0] == '3' || DAF_OS::strcasecmp(param_val.c_str(), "tg") == 0) {
                     this->tty_params.rtsenb = 3;
                 } else this->tty_params.rtsenb = 0;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "idsr") == 0) {
-                if (param_val[0] == '1' || ACE_OS::strcasecmp(param_val.c_str(), "on") == 0) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "idsr") == 0) {
+                if (param_val[0] == '1' || DAF_OS::strcasecmp(param_val.c_str(), "on") == 0) {
                     this->tty_params.dsrenb = true;
                 } this->tty_params.dsrenb = false;
-            } else if (ACE_OS::strcasecmp(param_arg.c_str(), "modem") == 0) {
-                if (param_val[0] == '1' || ACE_OS::strcasecmp(param_val.c_str(), "on") == 0) {
+            } else if (DAF_OS::strcasecmp(param_arg.c_str(), "modem") == 0) {
+                if (param_val[0] == '1' || DAF_OS::strcasecmp(param_val.c_str(), "on") == 0) {
                     this->tty_params.modem = true;
                 } this->tty_params.modem = false;
             } else if (1) /* Maybe Debug? */    {
@@ -352,7 +352,7 @@ namespace DEV
         case 'z':   this->device_debug_ = 1;
             for (const ACE_TCHAR *debug_lvl = get_opts.opt_arg(); debug_lvl;) {
                 if (::isdigit(int(*debug_lvl))) {
-                    this->device_debug_ = ace_range(1, 10, ACE_OS::atoi(debug_lvl));
+                    this->device_debug_ = ace_range(1, 10, DAF_OS::atoi(debug_lvl));
                 } break; // Turn on Debug optionally at a level
             } break;
 
@@ -386,7 +386,7 @@ namespace DEV
     {
         ACE_UNUSED_ARG(args);
 
-        this->set_handle(ACE_OS::open(this->tty_device_name.c_str(), O_RDWR | FILE_FLAG_OVERLAPPED , 0));
+        this->set_handle(DAF_OS::open(this->tty_device_name.c_str(), O_RDWR | FILE_FLAG_OVERLAPPED , 0));
         //this->enable(ACE_SIGIO);
         //this->enable(ACE_NONBLOCK);
 

--- a/TTY_Asynch/TTY_ReadStream.cpp
+++ b/TTY_Asynch/TTY_ReadStream.cpp
@@ -86,7 +86,7 @@ namespace DEV
                 iov_ptr     += int(io_len);
                 recv_len    += int(io_len);
 
-                ACE_OS::thr_yield();  // Yield a little for IO to Start
+                DAF_OS::thr_yield();  // Yield a little for IO to Start
             }
         }
 

--- a/TTY_Asynch/TTY_Stream.cpp
+++ b/TTY_Asynch/TTY_Stream.cpp
@@ -134,7 +134,7 @@ namespace DEV
                 } else if (io_len > 0 || (io_len += int(this->size_)) > 0) {
                     io_len = ace_min(iov_len, io_len, blen);
 
-                    ACE_OS::memcpy(this->ptr(head), &iov_buf[put_len], io_len);
+                    DAF_OS::memcpy(this->ptr(head), &iov_buf[put_len], io_len);
                     {
                         head = ((head + io_len) % this->size_); // Same as put_bump()
                     }
@@ -164,7 +164,7 @@ namespace DEV
                 } else if (io_len > 0 || (io_len += int(this->size_)) > 0) {
                     io_len = ace_min(iov_len, io_len, blen);
 
-                    ACE_OS::memcpy(&iov_buf[get_len], this->ptr(tail), io_len);
+                    DAF_OS::memcpy(&iov_buf[get_len], this->ptr(tail), io_len);
                     {
                         tail = ((tail + io_len) % this->size_); // Same as get_bump()
                     }
@@ -215,7 +215,7 @@ namespace DEV
             size_t len = ace_min(size_t(io_len), blen, this->size() / 2);
 
              // Used to debug troublesome circular buffer arithmetic (smiley)
-             //char s[128]; ACE_OS::sprintf(s, "Writer: len=%04d;io_len=%04d;head=%04d;tail=%04d;blen=%04d"
+             //char s[128]; DAF_OS::sprintf(s, "Writer: len=%04d;io_len=%04d;head=%04d;tail=%04d;blen=%04d"
              //       , len, io_len, head, tail, blen); std::cout << s << std::endl;
 
             ACE_Message_Block mb_data(this->ptr(tail), len); mb_data.wr_ptr(len);
@@ -223,7 +223,7 @@ namespace DEV
 //          ACE_DEBUG((LM_DEBUG, ACE_TEXT(">>TX-Send Length=%d\n"), len));
 
             if (len && this->send_stream(mb_data) == 0) {
-                ACE_OS::thr_yield(); return 0;
+                DAF_OS::thr_yield(); return 0;
             }
 
             DAF::print_last_error();
@@ -249,7 +249,7 @@ namespace DEV
             size_t len = ace_min(size_t(io_len), blen, this->size() / 2);
 
              // Used to debug troublesome circular buffer arithmetic (smiley)
-             //char s[128]; ACE_OS::sprintf(s, "Reader: len=%04d;io_len=%04d;head=%04d;tail=%04d;blen=%04d"
+             //char s[128]; DAF_OS::sprintf(s, "Reader: len=%04d;io_len=%04d;head=%04d;tail=%04d;blen=%04d"
              //       , len, io_len, head, tail, blen); std::cout << s << std::endl;
 
             ACE_Message_Block mb_data(this->ptr(head), len);
@@ -257,7 +257,7 @@ namespace DEV
 //          ACE_DEBUG((LM_DEBUG, ACE_TEXT(">>RX-Read Length=%d\n"), len));
 
             if (len && this->recv_stream(mb_data) == 0) {  // Start Next Read.
-                ACE_OS::thr_yield(); return 0;
+                DAF_OS::thr_yield(); return 0;
             }
 
             DAF::print_last_error();

--- a/TTY_Asynch/TTY_WriteStream.cpp
+++ b/TTY_Asynch/TTY_WriteStream.cpp
@@ -47,7 +47,7 @@ namespace DEV
         // Under Linux aio_write and aio_read get queued on the same file descriptor.
         // therefore we duplicate it here to allow concurrent aio_read and aio_write.
         // see "man dup"
-        this->write_handle_ = ACE_OS::dup(handler.handle());
+        this->write_handle_ = DAF_OS::dup(handler.handle());
         if ( this->write_handle_ != ACE_INVALID_HANDLE && this->open(handler, this->write_handle_) == 0) {
             ACE_GUARD_RETURN(ACE_SYNCH_MUTEX, mon, *this, -1); return this->signal_writer();
         }
@@ -91,7 +91,7 @@ namespace DEV
                 iov_ptr     += int(io_len);
                 send_len    += int(io_len);
 
-                ACE_OS::thr_yield();  // Yield a little for IO to Start
+                DAF_OS::thr_yield();  // Yield a little for IO to Start
             }
         }
 

--- a/daf/Bitset.cpp
+++ b/daf/Bitset.cpp
@@ -60,7 +60,7 @@ namespace DAF
                 this->bit_buffer_.reset(p); if (p == 0) {
                     DAF_THROW_EXCEPTION(DAF::ResourceExhaustionException);
                 }
-                ACE_OS::memset(p, (val ? -1 : 0), len);
+                DAF_OS::memset(p, (val ? -1 : 0), len);
 
                 if (val) this->trim_bits();
             }
@@ -79,7 +79,7 @@ namespace DAF
             this->bit_buffer_.reset(p); if (p == 0) {
                 DAF_THROW_EXCEPTION(DAF::ResourceExhaustionException);
             }
-            ACE_OS::memcpy(p, bitset, len);
+            DAF_OS::memcpy(p, bitset, len);
         }
     }
 
@@ -116,7 +116,7 @@ namespace DAF
                     }
                 }
                 else if ((i = (bit / BIT_BYTE_bits)) > 0) {
-                    return ACE_OS::memcmp(*this, bitset, size_t(i)) == 0;
+                    return DAF_OS::memcmp(*this, bitset, size_t(i)) == 0;
                 }
                 else break; // Should never happen
             }
@@ -137,7 +137,7 @@ namespace DAF
                 this->bit_buffer_.reset(p); if (p == 0) {
                     DAF_THROW_EXCEPTION(DAF::ResourceExhaustionException);
                 }
-                ACE_OS::memcpy(p, bitset, len); break;
+                DAF_OS::memcpy(p, bitset, len); break;
             }
 
             this->bit_buffer_.reset(0);
@@ -164,8 +164,8 @@ namespace DAF
                 BIT_BYTE_ptr p(0); ACE_NEW_NORETURN(p, BIT_BYTE_type[len]); if (p == 0) {
                     DAF_THROW_EXCEPTION(DAF::ResourceExhaustionException);
                 }
-                ACE_OS::memset(p, 0, len); if (pos) {
-                    ACE_OS::memcpy(p, *this, this->size());
+                DAF_OS::memset(p, 0, len); if (pos) {
+                    DAF_OS::memcpy(p, *this, this->size());
                 }
                 this->bit_buffer_.reset(p); break;
             }
@@ -249,7 +249,7 @@ namespace DAF
 
         if (this_bits == that_bits) {
             for (size_t len = this->size(); len;) {
-                return ACE_OS::memcmp(*this, bitset, len);
+                return DAF_OS::memcmp(*this, bitset, len);
             }
         }
 
@@ -319,7 +319,7 @@ namespace DAF
                 this->bit_buffer_.reset(p); if (p == 0) {
                     DAF_THROW_EXCEPTION(DAF::ResourceExhaustionException);
                 }
-                ACE_OS::memset(p, (val ? -1 : 0), len); this->bits_ = bits;
+                DAF_OS::memset(p, (val ? -1 : 0), len); this->bits_ = bits;
 
                 if (val) this->trim_bits();
 

--- a/daf/Configurator.cpp
+++ b/daf/Configurator.cpp
@@ -150,7 +150,7 @@ namespace DAF
     int
     Configurator::load(int &argc, ACE_TCHAR *argv[], bool use_env)
     {
-        if (this->config_switch() && ACE_OS::strlen(this->config_switch())) {
+        if (this->config_switch() && DAF_OS::strlen(this->config_switch())) {
 
             const std::string cfg_switch(DAF::trim_string(this->config_switch()));
             const std::string arg_switch("-" + cfg_switch);

--- a/daf/CountDownSemaphore.cpp
+++ b/daf/CountDownSemaphore.cpp
@@ -112,7 +112,7 @@ namespace DAF
                 if (this->count_ == 0) {
                     return 0;
                 }
-            } while (end_time >= ACE_OS::gettimeofday());
+            } while (end_time >= DAF_OS::gettimeofday());
         }
         return -1;
     }

--- a/daf/DAF.cpp
+++ b/daf/DAF.cpp
@@ -93,12 +93,12 @@ namespace DAF
 
         const char *p = reinterpret_cast<const char*>(buf);
 
-        char s[128]; ACE_OS::sprintf(s, ACE_TEXT("\nDAF_DUMP: Address = 0x%p, Length = %d"), p, int(len)); ss << s;
+        char s[128]; DAF_OS::sprintf(s, ACE_TEXT("\nDAF_DUMP: Address = 0x%p, Length = %d"), p, int(len)); ss << s;
 
         if (p) {
 
             for (int i = 0; len > 0; i++) {
-                ACE_OS::sprintf(s, ACE_TEXT("\n0x%04X -"), unsigned(i * width));
+                DAF_OS::sprintf(s, ACE_TEXT("\n0x%04X -"), unsigned(i * width));
                 size_t l_len = ace_min(width, len);
                 ss << s << hex_dump_data(p, l_len, width);
                 len -= l_len; p += l_len;
@@ -121,7 +121,7 @@ namespace DAF
 
         const char *p = reinterpret_cast<const char*>(buf);
 
-        char s[128]; ACE_OS::sprintf(s, ACE_TEXT("\nDAF_BitDump: Address = 0x%p, Length = %d bits"), p, int(bits)); ss << s;
+        char s[128]; DAF_OS::sprintf(s, ACE_TEXT("\nDAF_BitDump: Address = 0x%p, Length = %d bits"), p, int(bits)); ss << s;
 
         if (p && int(bits) > 0) {
 
@@ -139,7 +139,7 @@ namespace DAF
                         }
                     }
 
-                    ACE_OS::sprintf(s, ACE_TEXT("\n0x%04X - "), unsigned(i / 8)); ss << s;
+                    DAF_OS::sprintf(s, ACE_TEXT("\n0x%04X - "), unsigned(i / 8)); ss << s;
 
                 } while (false);
 
@@ -241,7 +241,7 @@ namespace DAF
         char s[64] = { 0 };
 
         if (error) for (const char * errno_text = DAF::get_errno_text(error); errno_text;) {
-            ACE_OS::sprintf(s, ACE_TEXT("[Error=%d (%s)]"), error, errno_text); break;
+            DAF_OS::sprintf(s, ACE_TEXT("[Error=%d (%s)]"), error, errno_text); break;
         }
 
         return s;

--- a/daf/DAF.h
+++ b/daf/DAF.h
@@ -70,7 +70,7 @@ namespace DAF
 
     DAF_Export const char * get_errno_text(int error = int(errno)); // NOTE: Could return 0
 
-    DAF_Export std::string  last_error_text(int error = ACE_OS::last_error());
+    DAF_Export std::string  last_error_text(int error = DAF_OS::last_error());
 
     DAF_Export std::string  trim_string(const std::string &, const char c = ' ');
 
@@ -86,7 +86,7 @@ namespace DAF
     DAF_Export void         print_args(const std::string &args, bool substitute_env_args = false);
     DAF_Export void         print_args(int argc, ACE_TCHAR *argv[], bool substitute_env_args = false);
 
-    DAF_Export int          print_last_error(int error = ACE_OS::last_error());
+    DAF_Export int          print_last_error(int error = DAF_OS::last_error());
 
     DAF_Export void         print_gestalt(const ACE_Service_Gestalt * sg = ACE_Service_Config::current());
 
@@ -103,31 +103,31 @@ namespace DAF
     ACE_hrtime_t            elapsed_hrtime(const ACE_hrtime_t &start, const ACE_hrtime_t &end);
 
     /**
-     * \fn ACE_hrtime_t elapsed_hrtime_msecs(const ACE_hrtime_t &start, const ACE_hrtime_t &end = ACE_OS::gethrtime(ACE_OS::ACE_HRTIMER_GETTIME))
+     * \fn ACE_hrtime_t elapsed_hrtime_msecs(const ACE_hrtime_t &start, const ACE_hrtime_t &end = DAF_OS::gethrtime(DAF_OS::ACE_HRTIMER_GETTIME))
      * \brief Calculate elapsed time between a start and end time in milliseconds (ms)
      * \param start The start time
      * \param end The end time
      * \return The elapsed time in milliseconds
      */
-    DAF_Export ACE_hrtime_t elapsed_hrtime_msecs(const ACE_hrtime_t &start, const ACE_hrtime_t &end = ACE_OS::gethrtime(ACE_OS::ACE_HRTIMER_GETTIME));
+    DAF_Export ACE_hrtime_t elapsed_hrtime_msecs(const ACE_hrtime_t &start, const ACE_hrtime_t &end = DAF_OS::gethrtime(DAF_OS::ACE_HRTIMER_GETTIME));
 
     /**
-    * \fn ACE_hrtime_t elapsed_hrtime_usecs(const ACE_hrtime_t &start, const ACE_hrtime_t &end = ACE_OS::gethrtime(ACE_OS::ACE_HRTIMER_GETTIME))
+    * \fn ACE_hrtime_t elapsed_hrtime_usecs(const ACE_hrtime_t &start, const ACE_hrtime_t &end = DAF_OS::gethrtime(DAF_OS::ACE_HRTIMER_GETTIME))
     * \brief Calculate elapsed time between a start and end time in microseconds (us)
     * \param start The start time
     * \param end The end time
     * \return The elapsed time in microseconds
     */
-    DAF_Export ACE_hrtime_t elapsed_hrtime_usecs(const ACE_hrtime_t &start, const ACE_hrtime_t &end = ACE_OS::gethrtime(ACE_OS::ACE_HRTIMER_GETTIME));
+    DAF_Export ACE_hrtime_t elapsed_hrtime_usecs(const ACE_hrtime_t &start, const ACE_hrtime_t &end = DAF_OS::gethrtime(DAF_OS::ACE_HRTIMER_GETTIME));
 
     /**
-    * \fn ACE_hrtime_t elapsed_hrtime_nsecs(const ACE_hrtime_t &start, const ACE_hrtime_t &end = ACE_OS::gethrtime(ACE_OS::ACE_HRTIMER_GETTIME))
+    * \fn ACE_hrtime_t elapsed_hrtime_nsecs(const ACE_hrtime_t &start, const ACE_hrtime_t &end = DAF_OS::gethrtime(DAF_OS::ACE_HRTIMER_GETTIME))
     * \brief Calculate elapsed time between a start and end time in nanoseconds (ns)
     * \param start The start time
     * \param end The end time
     * \return The elapsed time in nanoseconds
     */
-    DAF_Export ACE_hrtime_t elapsed_hrtime_nsecs(const ACE_hrtime_t &start, const ACE_hrtime_t &end = ACE_OS::gethrtime(ACE_OS::ACE_HRTIMER_GETTIME));
+    DAF_Export ACE_hrtime_t elapsed_hrtime_nsecs(const ACE_hrtime_t &start, const ACE_hrtime_t &end = DAF_OS::gethrtime(DAF_OS::ACE_HRTIMER_GETTIME));
 
 
     /** @class HighResTimer

--- a/daf/DAFDebug.cpp
+++ b/daf/DAFDebug.cpp
@@ -32,10 +32,10 @@ namespace {
     void    daf_print_debug(const char *id, int dbug)
     {
         char s[32]; if (dbug) {
-            ACE_OS::sprintf(s, ACE_TEXT("ON[%d]"), dbug);
+            DAF_OS::sprintf(s, ACE_TEXT("ON[%d]"), dbug);
         }
         else {
-            ACE_OS::strcpy(s, ACE_TEXT("OFF"));
+            DAF_OS::strcpy(s, ACE_TEXT("OFF"));
         }
         ACE_DEBUG((LM_INFO, ACE_TEXT("%s=%s - %T\n"), (id ? id : "Debug"), s));
     }

--- a/daf/DateTime.cpp
+++ b/daf/DateTime.cpp
@@ -64,7 +64,7 @@
 namespace {
 
     const struct _DateInitTime {
-        _DateInitTime(void) { ACE_OS::tzset(); }
+        _DateInitTime(void) { DAF_OS::tzset(); }
     } _tzTime;
 
     const int daysInCalanderMonth[] = { 0,

--- a/daf/Exception.h
+++ b/daf/Exception.h
@@ -28,7 +28,7 @@
 
 #define DAF_THROW_EXCEPTION(EXCEPT_TYPE) \
   do { char ss[128];                     \
-     ACE_OS::snprintf(ss,sizeof(ss),"%s(%d):%s",typeid(EXCEPT_TYPE).name(),__LINE__,__FILE__); \
+     DAF_OS::snprintf(ss,sizeof(ss),"%s(%d):%s",typeid(EXCEPT_TYPE).name(),__LINE__,__FILE__); \
      throw EXCEPT_TYPE(ss);              \
   } while (false) /* NOTE No Trailing ';' */
 

--- a/daf/PropertyManager.cpp
+++ b/daf/PropertyManager.cpp
@@ -31,7 +31,7 @@ namespace DAF
     namespace {
         struct AlphabeticalPredicate : std::binary_function < Configurator::value_type, Configurator::value_type, bool > {
             bool operator () (const first_argument_type &l, const second_argument_type &r) const {
-                return ACE_OS::strcasecmp(r.first.c_str(), l.first.c_str()) > 0; // this does a LowerCase Compare
+                return DAF_OS::strcasecmp(r.first.c_str(), l.first.c_str()) > 0; // this does a LowerCase Compare
             }
         };
     }
@@ -51,7 +51,7 @@ namespace DAF
 
             if (use_env) {
                 const char * env_val = DAF_OS::getenv(key.c_str()); use_env = false;
-                if (env_val && ACE_OS::strlen(env_val)) {
+                if (env_val && DAF_OS::strlen(env_val)) {
                     static_cast< ACE_SYNCH_RW_MUTEX & >(*this).tryacquire_write_upgrade(); // Try to switch to write access
                     if (const_cast<PropertyManager*>(this)->load_property(key, DAF::trim_string(env_val)) == 0) {
                         continue;
@@ -144,7 +144,7 @@ namespace DAF
     PropertySingleton::PropertySingleton(bool preload)
     {
         if (preload) { // Preload DAFProperties from environment variable if it exists
-            for (const char * properties = ACE_OS::getenv(this->config_switch()); properties;) try {
+            for (const char * properties = DAF_OS::getenv(this->config_switch()); properties;) try {
                 this->load_file_profile(properties); break;
             } DAF_CATCH_ALL {
                 ACE_ERROR_BREAK((LM_WARNING, ACE_TEXT("DAF (%P | %t) PropertySingleton:")

--- a/daf/SYNCHCondition_T.h
+++ b/daf/SYNCHCondition_T.h
@@ -114,7 +114,7 @@ namespace DAF
     {
         if (this->interrupted() ? this->waiters() > 0 : true) {
 
-            this->interrupted_ = true; ACE_OS::thr_yield(); // Set our flag.
+            this->interrupted_ = true; DAF_OS::thr_yield(); // Set our flag.
 
             const int REMOVE_RETRY_MAXIMUM = 3; // Retry's before throw on condition
 
@@ -126,13 +126,13 @@ namespace DAF
 
             const ACE_Time_Value remove_delay(0, 5000); // Delay 5ms after the broadcast
 
-            for (int i = REMOVE_RETRY_MAXIMUM; i--; ACE_OS::sleep(remove_delay)) {  // Allow threads to exit wait
+            for (int i = REMOVE_RETRY_MAXIMUM; i--; DAF_OS::sleep(remove_delay)) {  // Allow threads to exit wait
                 if (this->waiters() > 0) {
                     ACE_GUARD_ACTION(_mutex_type, cond_lock, this->condition_mutex_.mutex(), this->broadcast(), break);
                 } else return 0;
             }
 
-            ACE_OS::last_error(EBUSY); return -1;
+            DAF_OS::last_error(EBUSY); return -1;
         }
 
         return 0;
@@ -150,7 +150,7 @@ namespace DAF
         }
 
         if (this->interrupted()) {
-            ACE_OS::last_error(EINTR); DAF_THROW_EXCEPTION(DAF::InterruptedException);
+            DAF_OS::last_error(EINTR); DAF_THROW_EXCEPTION(DAF::InterruptedException);
         }
 
         return result;

--- a/daf/Semaphore.cpp
+++ b/daf/Semaphore.cpp
@@ -85,7 +85,7 @@ namespace DAF
         ACE_GUARD_REACTION(ACE_SYNCH_MUTEX, guard, *this, DAF_THROW_EXCEPTION(ResourceExhaustionException));
 
         if (this->interrupted()) {
-            ACE_OS::last_error(EINTR); DAF_THROW_EXCEPTION(DAF::InterruptedException);
+            DAF_OS::last_error(EINTR); DAF_THROW_EXCEPTION(DAF::InterruptedException);
         } else if (this->permits_ > this->waiters()) {
             --this->permits_; return 0;
         }
@@ -105,7 +105,7 @@ namespace DAF
         ACE_GUARD_REACTION(ACE_SYNCH_MUTEX, guard, *this, DAF_THROW_EXCEPTION(ResourceExhaustionException));
 
         if (this->interrupted()) {
-            ACE_OS::last_error(EINTR); DAF_THROW_EXCEPTION(DAF::InterruptedException);
+            DAF_OS::last_error(EINTR); DAF_THROW_EXCEPTION(DAF::InterruptedException);
         } else if (this->permits_ > this->waiters()) {
             --this->permits_; return 0;
         }
@@ -122,7 +122,7 @@ namespace DAF
             } while (end_time > DAF_OS::gettimeofday());
         }
 
-        ACE_OS::last_error(ETIME); return -1;
+        DAF_OS::last_error(ETIME); return -1;
     }
 
     int Semaphore::release(void)

--- a/daf/SemaphoreControlledChannel_T.cpp
+++ b/daf/SemaphoreControlledChannel_T.cpp
@@ -89,7 +89,7 @@ namespace DAF
     template<typename T> T
     SemaphoreControlledChannel<T>::poll(time_t msecs) throw (DAF::InternalException, DAF::TimeoutException)
     {
-        if (this->takeGuard_.attempt(msecs)) switch (ACE_OS::last_error()) {
+        if (this->takeGuard_.attempt(msecs)) switch (DAF_OS::last_error()) {
             case ETIME: DAF_THROW_EXCEPTION(DAF::TimeoutException); // Reverse the fact that we have been here and exit with error
             default:    DAF_THROW_EXCEPTION(DAF::InternalException);
         }

--- a/daf/ServiceGestalt.cpp
+++ b/daf/ServiceGestalt.cpp
@@ -61,7 +61,7 @@ namespace {
         , result_       (-1)
         , error_        (0)
     {
-        ACE_OS::last_error(0); // Reset Error Code for invoker
+        DAF_OS::last_error(0); // Reset Error Code for invoker
     }
 
     int
@@ -73,10 +73,10 @@ namespace {
             if ((this->result_ = this->gestalt_->process_directive(this->command_.c_str())) != 0) {
 #if defined(ACE_WIN32)
                 for (int error = ::GetLastError(); error;) {
-                    ACE_OS::last_error(error); break;
+                    DAF_OS::last_error(error); break;
                 }
 #endif
-                this->error_ = ACE_OS::last_error();
+                this->error_ = DAF_OS::last_error();
             }
 
         } DAF_CATCH_ALL{ /* Possible failure in user code */ }
@@ -88,10 +88,10 @@ namespace {
     ServiceAction::wait_result(time_t timeout) const
     {
         for (ACE_Time_Value tm(DAF_OS::gettimeofday(timeout)); this->resultLock_.acquire(tm);) {
-            ACE_OS::last_error(ACE_OS::last_error()); return -1;  // Possibly a timeout
+            DAF_OS::last_error(DAF_OS::last_error()); return -1;  // Possibly a timeout
         }
 
-        this->resultLock_.release(); ACE_OS::last_error(this->error_); return this->result_;
+        this->resultLock_.release(); DAF_OS::last_error(this->error_); return this->result_;
     }
 }
 
@@ -206,7 +206,7 @@ namespace DAF
             }
         }
 
-        ACE_OS::last_error(ENOEXEC); return -1;  // Not Executable
+        DAF_OS::last_error(ENOEXEC); return -1;  // Not Executable
     }
 
     std::string
@@ -218,7 +218,7 @@ namespace DAF
         s << ACE_TEXT("static ");
         s << ident;
         s << ACE_TEXT(" \"");
-        if (parameters && ACE_OS::strlen(parameters) > 0) {
+        if (parameters && DAF_OS::strlen(parameters) > 0) {
             s << parameters;
         }
         s << '"';
@@ -227,7 +227,7 @@ namespace DAF
         s << ACE_TEXT("<static id=\"");
         s << ident;
         s << '"';
-        if (parameters && ACE_OS::strlen(parameters) > 0) {
+        if (parameters && DAF_OS::strlen(parameters) > 0) {
             s << ACE_TEXT(" params=\"");
             s << parameters;
             s << '"';
@@ -252,7 +252,7 @@ namespace DAF
         s << ':';
         s << objectclass;
         s << ACE_TEXT("() \"");
-        if (parameters && ACE_OS::strlen(parameters) > 0) {
+        if (parameters && DAF_OS::strlen(parameters) > 0) {
             s << parameters;
         }
         s << '"';
@@ -266,7 +266,7 @@ namespace DAF
         s << ACE_TEXT("\" init=\"");
         s << objectclass;
         s << '"';
-        if (parameters && ACE_OS::strlen(parameters) > 0) {
+        if (parameters && DAF_OS::strlen(parameters) > 0) {
             s << ACE_TEXT(" params=\"");
             s << parameters;
             s << '"';

--- a/daf/ShutdownHandler.cpp
+++ b/daf/ShutdownHandler.cpp
@@ -92,7 +92,7 @@ namespace DAF
         {
             ACE_GUARD_RETURN(ACE_SYNCH_MUTEX, ace_mon, shutdown_monitor_, -1); shutdown_monitor_.notifyAll();
         }
-        ACE_OS::thr_yield(); return 0;
+        DAF_OS::thr_yield(); return 0;
     }
 
     int

--- a/daf/SignalHandler.cpp
+++ b/daf/SignalHandler.cpp
@@ -47,7 +47,7 @@ namespace DAF
             }
             ACE_DEBUG((LM_ERROR,
                 ACE_TEXT("FAILED to acquire Kernel eventfd (errno %d)\n")
-                , ACE_OS::last_error()));
+                , DAF_OS::last_error()));
 #endif
             return ACE_INVALID_HANDLE;
         }
@@ -104,7 +104,7 @@ namespace DAF
     {
 #if defined(DAF_HAS_EVENTFD) && (DAF_HAS_EVENTFD == 1)
         if (this->fd_ != ACE_INVALID_HANDLE) {
-            ACE_OS::close(this->fd_);
+            DAF_OS::close(this->fd_);
         }
 #endif
         this->cancel_all_timers(); this->reactor()->remove_handler(this, ACE_Event_Handler::DONT_CALL);
@@ -135,12 +135,12 @@ namespace DAF
         return ACE_Auto_Event::signal();
 #elif defined(DAF_HAS_EVENTFD) && (DAF_HAS_EVENTFD == 1)
         uint64_t input_d = 1;
-        if (ACE_OS::write(this->get_handle(), &input_d, sizeof(input_d)) == sizeof(input_d)) {
+        if (DAF_OS::write(this->get_handle(), &input_d, sizeof(input_d)) == sizeof(input_d)) {
             return 0;
         }
         ACE_DEBUG((LM_ERROR,
             ACE_TEXT("Failed to write to eventfd %d with (errno %d)\n")
-            , this->get_handle(), ACE_OS::last_error()));
+            , this->get_handle(), DAF_OS::last_error()));
 #endif
         return -1;
     }
@@ -195,11 +195,11 @@ namespace DAF
 #elif defined(DAF_HAS_EVENTFD) && (DAF_HAS_EVENTFD == 1)
         if (this->get_handle() == fd) {
             uint64_t output_d = 0;
-            if (ACE_OS::read(this->get_handle(), &output_d, sizeof(output_d)) == sizeof(output_d)) try {
+            if (DAF_OS::read(this->get_handle(), &output_d, sizeof(output_d)) == sizeof(output_d)) try {
                 return this->handle_event(fd, 0, 0);
             } catch (...) {
                 ACE_DEBUG((LM_ERROR, ACE_TEXT("Failed to read from eventfd %d (errno %d)\n")
-                    , this->get_handle(), ACE_OS::last_error()));
+                    , this->get_handle(), DAF_OS::last_error()));
                 throw;
             }
         }

--- a/daf/SynchronousChannel_T.cpp
+++ b/daf/SynchronousChannel_T.cpp
@@ -104,7 +104,7 @@ namespace DAF
 
         try {
 
-            if (this->itemAvailable_.attempt(msecs)) switch (ACE_OS::last_error()) {
+            if (this->itemAvailable_.attempt(msecs)) switch (DAF_OS::last_error()) {
             case ETIME: DAF_THROW_EXCEPTION(DAF::TimeoutException); // Reverse the fact that we have been here and exit with error
             default:    DAF_THROW_EXCEPTION(DAF::InternalException);
             }

--- a/daf/TaskExecutor.cpp
+++ b/daf/TaskExecutor.cpp
@@ -335,12 +335,12 @@ namespace DAF
                 }
 
 #if defined(ACE_TANDEM_T1248_PTHREADS)
-                ACE_OS::memcpy(&this->last_thread_id_, 0, sizeof(this->last_thread_id_));
+                DAF_OS::memcpy(&this->last_thread_id_, 0, sizeof(this->last_thread_id_));
 #else
                 this->last_thread_id_ = 0;    // Reset to prevent inadvertant match on ID
 #endif /* defined (ACE_TANDEM_T1248_PTHREADS) */
 
-                ACE_OS::thr_yield(); return 0; // Let The Thread(s) start up (Still Locked though)
+                DAF_OS::thr_yield(); return 0; // Let The Thread(s) start up (Still Locked though)
 
             } while (false);
         }
@@ -384,11 +384,11 @@ namespace DAF
                 break;
             }
 
-            ACE_OS::thr_setprio(ACE_Sched_Priority(cmd->runPriority())); // Set the requested priority
+            DAF_OS::thr_setprio(ACE_Sched_Priority(cmd->runPriority())); // Set the requested priority
 
-            ACE_OS::last_error(0); this->svc(cmd._retn()); // Dispatch The Command
+            DAF_OS::last_error(0); this->svc(cmd._retn()); // Dispatch The Command
 
-            ACE_OS::thr_setprio(default_prio);  // Reset Priority
+            DAF_OS::thr_setprio(default_prio);  // Reset Priority
         }
 
         cmd = DAF::Runnable::_nil(); return 0;
@@ -421,14 +421,14 @@ namespace DAF
                     }
 
 #if defined(ACE_TANDEM_T1248_PTHREADS)
-                    ACE_OS::memset(&this->last_thread_id_, 0, sizeof(this->last_thread_id_));
+                    DAF_OS::memset(&this->last_thread_id_, 0, sizeof(this->last_thread_id_));
 #else
                     this->last_thread_id_ = 0;    // Reset to prevent inadvertant match on ID
 #endif /* defined (ACE_TANDEM_T1248_PTHREADS) */
                 }
             }
 
-            ACE_OS::thr_yield(); return 0; // Let The Thread start up
+            DAF_OS::thr_yield(); return 0; // Let The Thread start up
 
         } while (false);
 
@@ -478,7 +478,7 @@ namespace DAF
 
         time_t evictTimeout = this->getEvictTimeout(); // Start with the full evict timeout value.
 
-        for (int evict_retry = TASK_EVICT_RETRY_MAXIMUM; (ACE_OS::thr_yield(), this->isActive()); evictTimeout /= 2) {
+        for (int evict_retry = TASK_EVICT_RETRY_MAXIMUM; (DAF_OS::thr_yield(), this->isActive()); evictTimeout /= 2) {
 
             try {
 
@@ -548,7 +548,7 @@ namespace DAF
             try {
 
                 if (this->cancel_thr(td, true)) { // Cancel the thread
-                    int error = ACE_OS::last_error();
+                    int error = DAF_OS::last_error();
                     switch (error) {
                     case 0: break;
 #if defined(ACE_WIN32)
@@ -559,7 +559,7 @@ namespace DAF
                         if (::TerminateThread(td->threadHandle(), DWORD(0xDEAD))) {
                             break;
                         }
-                        error = ACE_OS::last_error(); // Fall though with terminate error
+                        error = DAF_OS::last_error(); // Fall though with terminate error
 # endif
 #endif
                     default:

--- a/tests/BarrierTest/BarrierTest.cpp
+++ b/tests/BarrierTest/BarrierTest.cpp
@@ -126,7 +126,7 @@ int test_NoBarrierCommand(int threadCount )
         const int barrierResult = barrier.barrier();
         ACE_UNUSED_ARG(barrierResult);
 
-        ACE_OS::thr_yield();
+        DAF_OS::thr_yield();
 
         value = count;
     }
@@ -165,7 +165,7 @@ int test_BarrierCommand(int threadCount)
         const int barrierResult = barrier.barrier();
         ACE_UNUSED_ARG(barrierResult);
 
-        ACE_OS::thr_yield();
+        DAF_OS::thr_yield();
 
         value = count ;
     }
@@ -208,7 +208,7 @@ int test_BarrierBrokenException(int threadCount)
             value++;
         }
 
-        ACE_OS::sleep(1);
+        DAF_OS::sleep(1);
         // Not sure why this value is not correct ? -> 0 ? coz the exception is thrown
         //value = reinterpret_cast<TestBarrier*>(broken.ptr())->broken_ ;
         //if (debug) ACE_DEBUG((LM_DEBUG, "(%P|%t) %T - 0x%08X Broken Count %d\n", broken.ptr(), value));
@@ -249,10 +249,10 @@ int test_BarrierIllegalStateException(int threadCount)
         executor.execute(illegal);
 
         blocker.acquire();
-        ACE_OS::sleep(1);
+        DAF_OS::sleep(1);
 
         delete barrier;
-        ACE_OS::sleep(1);
+        DAF_OS::sleep(1);
     }
 
     value = reinterpret_cast<TestBarrier*>(illegal.ptr())->illegal_;
@@ -285,7 +285,7 @@ int test_BarrierTimeoutException(int threadCount )
         for (int i = 0 ; i < threadCount; ++i)
         {
             executor.execute(timeout);
-            ACE_OS::sleep(ACE_Time_Value(0, 500000));
+            DAF_OS::sleep(ACE_Time_Value(0, 500000));
         }
 
         value = reinterpret_cast<TestBarrier*>(timeout.ptr())->timeout_;
@@ -324,7 +324,7 @@ int test_BarrierWaitResetClean(int threadCount)
             blocker.acquire();
             blocker.acquire();
 
-            ACE_OS::sleep(ACE_Time_Value(0, 5000));
+            DAF_OS::sleep(ACE_Time_Value(0, 5000));
 
             bool clean = barrier.waitReset();
             result &= !barrier.broken() && clean;
@@ -378,7 +378,7 @@ int test_BarrierWaitResetTimeout(int threadCount)
         result &= barrier.broken() && !clean;
 
         if (debug) ACE_DEBUG((LM_DEBUG, "(%P|%t) %T - Clean Wait %s %d\n", (clean ? "YES" : "NO"), result));
-        ACE_OS::sleep(ACE_Time_Value(1));
+        DAF_OS::sleep(ACE_Time_Value(1));
     }
 
     value = tester->broken_  + tester->unknown_ + tester->illegal_  ;
@@ -472,12 +472,12 @@ int test_BarrierThreadKill(int threadCount)
         if (debug) ACE_DEBUG((LM_DEBUG, "(%P|%t) %T - Killing the TaskExecutor\n"));
         delete kill_executor;
 
-        ACE_OS::sleep(ACE_Time_Value(1,0));
+        DAF_OS::sleep(ACE_Time_Value(1,0));
 
         //result &= barrier.broken();
 
         if (debug) ACE_DEBUG((LM_DEBUG, "(%P|%t) %T - Clean Wait %s %d\n", (clean ? "YES" : "NO"), result));
-        ACE_OS::sleep(ACE_Time_Value(1));
+        DAF_OS::sleep(ACE_Time_Value(1));
     }
 
     value = tester->broken_  + tester->unknown_ + tester->illegal_  ;
@@ -515,7 +515,7 @@ int main(int argc, char *argv[])
         case -1: break;
         case 'h': print_usage(cli_opt); return 0;
         case 'z': DAF::debug(true); test::debug=true; break;
-        case 'n': threadCount = ACE_OS::atoi(cli_opt.opt_arg());
+        case 'n': threadCount = DAF_OS::atoi(cli_opt.opt_arg());
     }
 
     std::cout << test::TEST_NAME << std::endl;

--- a/tests/BitsetTest/BitsetTest.cpp
+++ b/tests/BitsetTest/BitsetTest.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
     {
         bitset.reset(9, true);
 
-        if (bitset.size() != sizeof(BUF_9_BITS_TRUE) || ACE_OS::memcmp(bitset.bit_buffer(), BUF_9_BITS_TRUE, bitset.size())) {
+        if (bitset.size() != sizeof(BUF_9_BITS_TRUE) || DAF_OS::memcmp(bitset.bit_buffer(), BUF_9_BITS_TRUE, bitset.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed to Initialize Buffer Correctly%s")
                 , DAF::bit_dump(bitset, bitset.bits()).c_str()), -1);
         }
@@ -61,8 +61,8 @@ int main(int argc, char *argv[])
 
         do {
             if (bitset.size() == sizeof(BUF_MIN_BITS_TRUE) && bitset_cpy.size() == sizeof(BUF_MIN_BITS_TRUE)) {
-                if (ACE_OS::memcmp(bitset.bit_buffer(), BUF_MIN_BITS_TRUE, bitset.size()) == 0) {
-                    if (ACE_OS::memcmp(bitset_cpy.bit_buffer(), BUF_MIN_BITS_TRUE, bitset_cpy.size()) == 0) {
+                if (DAF_OS::memcmp(bitset.bit_buffer(), BUF_MIN_BITS_TRUE, bitset.size()) == 0) {
+                    if (DAF_OS::memcmp(bitset_cpy.bit_buffer(), BUF_MIN_BITS_TRUE, bitset_cpy.size()) == 0) {
                         break;
                     }
                 }
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed subits with incorrect length %d\n")
                 , int(subits.bits())), -1);
         }
-        else if (ACE_OS::memcmp(subits, BUF_SUBITS_SET, subits.size())) {
+        else if (DAF_OS::memcmp(subits, BUF_SUBITS_SET, subits.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed subits with wrong bits set%s")
                 , DAF::bit_dump(subits, subits.bits()).c_str()), -1);
         }
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed erase with incorrect length %d\n")
                 , int(erasebits.bits())), -1);
         }
-        else if (ACE_OS::memcmp(erasebits, BUF_ERASE_SET, erasebits.size())) {
+        else if (DAF_OS::memcmp(erasebits, BUF_ERASE_SET, erasebits.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed erase with wrong bits set%s")
                 , DAF::bit_dump(erasebits, erasebits.bits()).c_str()), -1);
         }
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed erase with incorrect length %d\n")
                 , int(erasebits.bits())), -1);
         }
-        else if (ACE_OS::memcmp(erasebits, BUF_ERASE_SET, erasebits.size())) {
+        else if (DAF_OS::memcmp(erasebits, BUF_ERASE_SET, erasebits.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed erase with wrong bits set%s")
                 , DAF::bit_dump(erasebits, erasebits.bits()).c_str()), -1);
         }
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed ~ with incorrect length %d\n")
                 , int(bINV.bits())), -1);
         }
-        else if (ACE_OS::memcmp(bINV, BUF_MAX_BITS_ZERO, bINV.size())) {
+        else if (DAF_OS::memcmp(bINV, BUF_MAX_BITS_ZERO, bINV.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed ~ with wrong bits set%s")
                 , DAF::bit_dump(bINV, bINV.bits()).c_str()), -1);
         }
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
         if (boolbits.size() != sizeof(BUF_MAX_BITS_TRUE)) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed &= with incorrect length\n")), -1);
         }
-        else if (ACE_OS::memcmp(boolbits, BUF_MAX_BITS_TRUE, boolbits.size())) {
+        else if (DAF_OS::memcmp(boolbits, BUF_MAX_BITS_TRUE, boolbits.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed &= with wrong bits set%s")
                 , DAF::bit_dump(boolbits, boolbits.bits()).c_str()), -1);
         }
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
         if (boolbits.size() != sizeof(BUF_MAX_BITS_ZERO)) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed ^= with incorrect length\n")), -1);
         }
-        else if (ACE_OS::memcmp(boolbits, BUF_MAX_BITS_ZERO, boolbits.size())) {
+        else if (DAF_OS::memcmp(boolbits, BUF_MAX_BITS_ZERO, boolbits.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed ^= with wrong bits set\n")), -1);
         }
     }
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
         if (boolbits.size() != sizeof(BUF_MAX_BITS_TRUE)) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed |= with incorrect length\n")), -1);
         }
-        else if (ACE_OS::memcmp(boolbits, BUF_MAX_BITS_TRUE, boolbits.size())) {
+        else if (DAF_OS::memcmp(boolbits, BUF_MAX_BITS_TRUE, boolbits.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed |= with wrong bits set\n")), -1);
         }
     }
@@ -176,7 +176,7 @@ int main(int argc, char *argv[])
 
     std::cout << "Testing == Bitset ";
     {
-        if (bitset.size() != sizeof(BUF_MAX_BITS_TRUE) || ACE_OS::memcmp(bitset.bit_buffer(), BUF_MAX_BITS_TRUE, bitset.size())) {
+        if (bitset.size() != sizeof(BUF_MAX_BITS_TRUE) || DAF_OS::memcmp(bitset.bit_buffer(), BUF_MAX_BITS_TRUE, bitset.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed to Initialize Buffer Correctly")), -1);
         }
         else if (bitset != DAF::Bitset(MAX_BITS - 1, true)) {  // Only checks overlapping bits
@@ -216,7 +216,7 @@ int main(int argc, char *argv[])
         if (b_add.size() != sizeof(BUF_MAX_ADD_SET)) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed in '+' to increase buffer size\n")), -1);
         }
-        else if (ACE_OS::memcmp(b_add, BUF_MAX_ADD_SET, b_add.size())) {
+        else if (DAF_OS::memcmp(b_add, BUF_MAX_ADD_SET, b_add.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed '+' with wrong Bits\n")), -1);
         }
     }
@@ -228,7 +228,7 @@ int main(int argc, char *argv[])
         if ((bitset[1] = false) ? true : false)  {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed to set false\n")), -1);
         }
-        else if (ACE_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
+        else if (DAF_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed with different Bits\n")), -1);
         }
     }
@@ -239,13 +239,13 @@ int main(int argc, char *argv[])
         if (!bitset[1] ? false : true) { // Bit 0 is true HERE!!
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed !true != false\n")), -1);
         }
-        else if ((bitset[1] = !bitset[1]) ? ACE_OS::memcmp(bitset.bit_buffer(), BUF_MAX_BITS_TRUE, bitset.size()) : true) {
+        else if ((bitset[1] = !bitset[1]) ? DAF_OS::memcmp(bitset.bit_buffer(), BUF_MAX_BITS_TRUE, bitset.size()) : true) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed to set true\n")), -1);
         }
         else if (!(bitset[1] = false) ? false : true)  {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed !true != false\n")), -1);
         }
-        else if (ACE_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
+        else if (DAF_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed in ! operator buffer state\n")), -1);
         }
     }
@@ -270,19 +270,19 @@ int main(int argc, char *argv[])
 
     std::cout << "Testing ^= operator ";
     {
-        if (ACE_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
+        if (DAF_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed to initialize to false\n")), -1);
         }
-        else if ((bitset[1] ^= true) ? ACE_OS::memcmp(bitset, BUF_MAX_BITS_TRUE, bitset.size()) : true) {
+        else if ((bitset[1] ^= true) ? DAF_OS::memcmp(bitset, BUF_MAX_BITS_TRUE, bitset.size()) : true) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed (false ^ true) != true")), -1);
         }
-        else if ((bitset[1] ^= false) ? ACE_OS::memcmp(bitset, BUF_MAX_BITS_TRUE, bitset.size()) : true) {
+        else if ((bitset[1] ^= false) ? DAF_OS::memcmp(bitset, BUF_MAX_BITS_TRUE, bitset.size()) : true) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed (true ^ false) != true")), -1);
         }
-        else if ((bitset[1] ^= true) || ACE_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
+        else if ((bitset[1] ^= true) || DAF_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed (true ^ true)  != false")), -1);
         }
-        else if ((bitset[1] ^= false) || ACE_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
+        else if ((bitset[1] ^= false) || DAF_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed (false ^ false) != false")), -1);
         }
     }
@@ -293,10 +293,10 @@ int main(int argc, char *argv[])
         if (bitset[1] |= false) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed (false | false) != false")), -1);
         }
-        else if ((bitset[1] |= true) ? ACE_OS::memcmp(bitset, BUF_MAX_BITS_TRUE, bitset.size()) : true) {
+        else if ((bitset[1] |= true) ? DAF_OS::memcmp(bitset, BUF_MAX_BITS_TRUE, bitset.size()) : true) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed (false | true) != true")), -1);
         }
-        else if ((bitset[1] |= false) ? ACE_OS::memcmp(bitset, BUF_MAX_BITS_TRUE, bitset.size()) : true) {
+        else if ((bitset[1] |= false) ? DAF_OS::memcmp(bitset, BUF_MAX_BITS_TRUE, bitset.size()) : true) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed (true | false) != true")), -1);
         }
     }
@@ -304,13 +304,13 @@ int main(int argc, char *argv[])
 
     std::cout << "Testing &= operator ";
     {
-        if ((bitset[1] &= true) ? ACE_OS::memcmp(bitset, BUF_MAX_BITS_TRUE, bitset.size()) : false) {
+        if ((bitset[1] &= true) ? DAF_OS::memcmp(bitset, BUF_MAX_BITS_TRUE, bitset.size()) : false) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed (true & true)   != true")), -1);
         }
-        else if ((bitset[1] &= false) || ACE_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
+        else if ((bitset[1] &= false) || DAF_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed (true & false)  != false")), -1);
         }
-        else if ((bitset[1] &= false) || ACE_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
+        else if ((bitset[1] &= false) || DAF_OS::memcmp(bitset, BUF_MAX_BITS_SET, bitset.size())) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed (false & false) != false")), -1);
         }
     }
@@ -324,7 +324,7 @@ int main(int argc, char *argv[])
             }
         }
         catch (const std::out_of_range&) {
-            if (ACE_OS::memcmp(bitset, BUF_MAX_BITS_SET, sizeof(BUF_MAX_BITS_SET))) {
+            if (DAF_OS::memcmp(bitset, BUF_MAX_BITS_SET, sizeof(BUF_MAX_BITS_SET))) {
                 ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed in Range Check with resultant buffer state\n")), -1);
             }
         }

--- a/tests/FutureResultTest/FutureResultTest.cpp
+++ b/tests/FutureResultTest/FutureResultTest.cpp
@@ -485,7 +485,7 @@ int main(int argc, char *argv[])
         case -1: break;
         case 'h': print_usage(cli_opt); return 0;
         case 'z': DAF::debug(true); test::debug=true; break;
-        case 'n': threadCount = ACE_OS::atoi(cli_opt.opt_arg());
+        case 'n': threadCount = DAF_OS::atoi(cli_opt.opt_arg());
     }
 
     std::cout << test::TEST_NAME << std::endl;

--- a/tests/MonitorTest/MonitorChannelTest.cpp
+++ b/tests/MonitorTest/MonitorChannelTest.cpp
@@ -140,7 +140,7 @@ namespace test
       if (debug) ACE_DEBUG((LM_DEBUG, "(%P|%t) %T - Killing the Monitor\n"));
       delete monitor;
 
-      ACE_OS::sleep(ACE_Time_Value(1,0));
+      DAF_OS::sleep(ACE_Time_Value(1,0));
 
 
 
@@ -197,7 +197,7 @@ namespace test
       if (debug) ACE_DEBUG((LM_DEBUG, "(%P|%t) %T - Killing the Channel\n"));
       delete channel;
 
-      ACE_OS::sleep(ACE_Time_Value(1,0));
+      DAF_OS::sleep(ACE_Time_Value(1,0));
 
 
 
@@ -245,7 +245,7 @@ int main(int argc, char *argv[])
     case -1: break;
     case 'h': print_usage(cli_opt); return 0;
     case 'z': DAF::debug(true); test::debug=true; break;
-    case 'n': threadCount = ACE_OS::atoi(cli_opt.opt_arg());
+    case 'n': threadCount = DAF_OS::atoi(cli_opt.opt_arg());
   }
 
   std::cout << test::TEST_NAME << std::endl;

--- a/tests/MonitorTest/MonitorTest.cpp
+++ b/tests/MonitorTest/MonitorTest.cpp
@@ -65,7 +65,7 @@ namespace
         ACE_UNUSED_ARG(argc); ACE_UNUSED_ARG(argv);
 
         if (this->execute(new MonitorRunnable()) == 0) {
-            ACE_OS::sleep(1); return this->execute(1);
+            DAF_OS::sleep(1); return this->execute(1);
         }
         return -1;
     }
@@ -97,7 +97,7 @@ namespace
 
         try {
             ACE_GUARD_RETURN(ACE_SYNCH_MUTEX, mon, monitor_, -1);
-            int i = monitor_.wait(), j = ACE_OS::last_error();
+            int i = monitor_.wait(), j = DAF_OS::last_error();
             if (i) {
                 ACE_ERROR_RETURN((LM_INFO, ACE_TEXT("%P | %t) - MonitorTest return =%d;errno=%d"), i, j), -1);
             }

--- a/tests/Performance/STATSData.cpp
+++ b/tests/Performance/STATSData.cpp
@@ -29,7 +29,7 @@ namespace PERF
     STATSData::STATSData(const std::string &ident)
         : ACE_Semaphore(0), timeCount_(0), ident_(ident)
     {
-        ACE_OS::memset(&this->timeData_, 0, sizeof(this->timeData_));
+        DAF_OS::memset(&this->timeData_, 0, sizeof(this->timeData_));
     }
 
     double &
@@ -44,7 +44,7 @@ namespace PERF
     const std::string
     STATSData::calculate_stats(void) const
     {
-        char s[128]; ACE_OS::sprintf(s, "count=%u,mean=%4.4f,sd=%4.4f",
+        char s[128]; DAF_OS::sprintf(s, "count=%u,mean=%4.4f,sd=%4.4f",
             unsigned(this->timeCount_),
             this->calculate_mean(),
             this->calculate_sd());

--- a/tests/RendezvousTest/RendezvousTest.cpp
+++ b/tests/RendezvousTest/RendezvousTest.cpp
@@ -62,7 +62,7 @@ namespace test
         {
             ran = true;
             if (debug) ACE_DEBUG((LM_INFO, "(%P|%t) %T 0x%08X Running Rendezvous Functor\n", this));
-            ACE_OS::sleep(this->delay);
+            DAF_OS::sleep(this->delay);
             if (debug) ACE_DEBUG((LM_INFO, "(%P|%t) %T 0x%08X Executing Rendezvous Functor\n", this));
 
             for ( size_t i = 0 ; i < v.size(); i++ )
@@ -113,7 +113,7 @@ namespace test
 
        virtual int run(void)
        {
-           if ( delay_msec ) ACE_OS::sleep(ACE_Time_Value(0, suseconds_t(delay_msec)));
+           if ( delay_msec ) DAF_OS::sleep(ACE_Time_Value(0, suseconds_t(delay_msec)));
 
            if ( debug ) ACE_DEBUG((LM_INFO, "(%P|%t) %T 0x%08X Entering Rendezvous %d\n", this, this->id));
 
@@ -223,7 +223,7 @@ namespace test
                 if(debug) ACE_DEBUG((LM_DEBUG, "(%P|%t) %T - Got Illegal State? %s\n", te.what()));
                 result = 0;
             }
-            ACE_OS::thr_yield();
+            DAF_OS::thr_yield();
         }
 
         value = tester->broken;
@@ -281,7 +281,7 @@ namespace test
                 if(debug) ACE_DEBUG((LM_DEBUG, "(%P|%t) %T - Got Illegal State? %s\n", te.what()));
                 result = 0;
             }
-            ACE_OS::thr_yield();
+            DAF_OS::thr_yield();
         }
 
         value = tester->broken;
@@ -337,7 +337,7 @@ namespace test
                 if(debug) ACE_DEBUG((LM_DEBUG, "(%P|%t) %T - Got Illegal State? %s\n", te.what()));
                 result = 0;
             }
-            ACE_OS::thr_yield();
+            DAF_OS::thr_yield();
         }
 
         value = tester->broken;
@@ -388,7 +388,7 @@ namespace test
 
             result = rend.waitReset(100) && !rend.broken();
 
-            ACE_OS::thr_yield();
+            DAF_OS::thr_yield();
         }
 
         value = tester->broken;
@@ -424,7 +424,7 @@ namespace test
             for ( int i = 0; i < threadCount; ++i )
             {
                 executor.execute(timeout);
-                ACE_OS::sleep(ACE_Time_Value(0, 500000));
+                DAF_OS::sleep(ACE_Time_Value(0, 500000));
             }
 
             value = reinterpret_cast<TestRendezvous*>(timeout.ptr())->timeout;
@@ -541,7 +541,7 @@ namespace test
             }
 
             rendez.rendezvous(1);
-            ACE_OS::sleep(ACE_Time_Value(0, 500));
+            DAF_OS::sleep(ACE_Time_Value(0, 500));
         }
 
         value = functor.value;
@@ -594,7 +594,7 @@ namespace test
             // Deliberately Destroy the Rendezvous
             // to make sure the destruction process doesn't deadlock.
             delete rend;
-            ACE_OS::thr_yield();
+            DAF_OS::thr_yield();
         }
 
         value = tester->illegal + tester->broken;
@@ -652,7 +652,7 @@ namespace test
             // Deliberately Destroy the Rendezvous
             // to make sure the destruction process doesn't deadlock.
             delete rend;
-            ACE_OS::thr_yield();
+            DAF_OS::thr_yield();
         }
 
         // TODO Test Condition? - If it got here it didn't deadlock ?
@@ -751,7 +751,7 @@ namespace test
 
             delete kill_executor;
 
-            ACE_OS::thr_yield();
+            DAF_OS::thr_yield();
             //result &= rend.broken();
 
 
@@ -791,7 +791,7 @@ int main(int argc, char *argv[])
         case -1: break;
         case 'h': print_usage(cli_opt); return 0;
         case 'z': DAF::debug(true); test::debug=true; break;
-        case 'n': threadCount = ACE_OS::atoi(cli_opt.opt_arg());
+        case 'n': threadCount = DAF_OS::atoi(cli_opt.opt_arg());
     }
 
     std::cout << test::TEST_NAME << std::endl;

--- a/tests/SemaphoreChannelTest/ChannelTest.cpp
+++ b/tests/SemaphoreChannelTest/ChannelTest.cpp
@@ -65,7 +65,7 @@ namespace test
                 ACE_DEBUG((LM_INFO, "(%P|%t) %T LongAss Assignment Waiting %d msecs\n", wait_time));
             }
 
-            ACE_OS::sleep(ACE_Time_Value(wait_time/1000,(wait_time%1000)*1000));
+            DAF_OS::sleep(ACE_Time_Value(wait_time/1000,(wait_time%1000)*1000));
             return *this;
         }
     };
@@ -274,7 +274,7 @@ namespace test
 
             counter.acquire();
 
-            ACE_OS::sleep(1);
+            DAF_OS::sleep(1);
         }
 
         value = tester->timeout;
@@ -316,7 +316,7 @@ namespace test
 
             counter.acquire();
 
-            ACE_OS::sleep(1);
+            DAF_OS::sleep(1);
         }
 
         value = tester->timeout;
@@ -367,7 +367,7 @@ namespace test
             // does our channel still function
             channel.put(expected);
 
-            ACE_OS::sleep(1);
+            DAF_OS::sleep(1);
         }
 
         value = tester->value;
@@ -410,7 +410,7 @@ namespace test
 
             counter.acquire();
 
-            ACE_OS::sleep(1);
+            DAF_OS::sleep(1);
 
             // At this point my killer is sitting on the guard
             // and we may have lost a value on the unclaimedTakers_ count
@@ -429,7 +429,7 @@ namespace test
 
             counter.acquire();
 
-            ACE_OS::sleep(1);
+            DAF_OS::sleep(1);
         }
 
         value = tester->value;
@@ -486,7 +486,7 @@ namespace test
 
             counter.acquire();
 
-            ACE_OS::sleep(1);
+            DAF_OS::sleep(1);
         }
 
         value = tester->value;
@@ -525,7 +525,7 @@ namespace test
 
             counter.acquire();
 
-            ACE_OS::sleep(1);
+            DAF_OS::sleep(1);
         }
 
         value = tester->timeout;
@@ -578,7 +578,7 @@ namespace test
             counter.acquire();
 
 
-            ACE_OS::sleep(2);
+            DAF_OS::sleep(2);
         }
 
         value = tester->result;
@@ -644,7 +644,7 @@ namespace test
 
 
 
-            ACE_OS::sleep(2);
+            DAF_OS::sleep(2);
         }
 
         value = tester->value.value;
@@ -681,7 +681,7 @@ int main(int argc, char *argv[])
         case -1: break;
         case 'h': print_usage(cli_opt); return 0;
         case 'z': DAF::debug(true); test::debug=true; break;
-        case 'n': threadCount = ACE_OS::atoi(cli_opt.opt_arg());
+        case 'n': threadCount = DAF_OS::atoi(cli_opt.opt_arg());
     }
 
     std::cout << test::TEST_NAME << std::endl;

--- a/tests/SemaphoreChannelTest/SemaphoreChannelTest.cpp
+++ b/tests/SemaphoreChannelTest/SemaphoreChannelTest.cpp
@@ -64,7 +64,7 @@ namespace test
             for(int i = 0; i < 10; i++) {
                 this->testChannel().put(TestValue(i));
             }
-            ACE_OS::sleep(2); return 0;
+            DAF_OS::sleep(2); return 0;
         }
 
     protected:

--- a/tests/SemaphoreTest/SemaphoreTest.cpp
+++ b/tests/SemaphoreTest/SemaphoreTest.cpp
@@ -274,13 +274,13 @@ namespace test
             executor.execute(runner);
 
             while(executor.size() < 1) {
-                ACE_OS::sleep(ACE_Time_Value(0,300));
+                DAF_OS::sleep(ACE_Time_Value(0,300));
             }
-            ACE_OS::sleep(ACE_Time_Value(1,300));
+            DAF_OS::sleep(ACE_Time_Value(1,300));
 
             sema.release();
 
-            ACE_OS::sleep(ACE_Time_Value(1, 5000));
+            DAF_OS::sleep(ACE_Time_Value(1, 5000));
         }
 
         value = tester->permit_exit == tester->permit_entry;
@@ -318,9 +318,9 @@ namespace test
             kill_executor->execute(new TestSemaphore(sema));
 
             while(executor.size() < 1 && kill_executor->size() < 1) {
-                ACE_OS::sleep(ACE_Time_Value(0,300));
+                DAF_OS::sleep(ACE_Time_Value(0,300));
             }
-            ACE_OS::sleep(ACE_Time_Value(1,300));
+            DAF_OS::sleep(ACE_Time_Value(1,300));
 
             // Kill the Executor
             if ( debug) ACE_DEBUG((LM_INFO, "(%P|%t) %T - Killing Executor\n"));
@@ -331,7 +331,7 @@ namespace test
 
             sema.release();
 
-            ACE_OS::sleep(ACE_Time_Value(1, 5000));
+            DAF_OS::sleep(ACE_Time_Value(1, 5000));
         }
 
         value = tester->permit_exit == tester->permit_entry;
@@ -390,7 +390,7 @@ namespace test
 
            if (debug) ACE_DEBUG((LM_INFO, "(%P|%t) %T - R2 Executor Size %d semaphore permits %d waiters %d\n", executor.size(), sema.permits(), sema.waiters()));
 
-           ACE_OS::sleep(ACE_Time_Value(0,5000));
+           DAF_OS::sleep(ACE_Time_Value(0,5000));
            value = sema.waiters();
 
            // Clear out the rest - test is over.
@@ -463,7 +463,7 @@ namespace test
           sema.release();
 
           if (debug) ACE_DEBUG((LM_INFO, "(%P|%t) %T - R2 Executor Size %d semaphore permits %d waiters %d\n", executor.size(), sema.permits(), sema.waiters()));
-          ACE_OS::sleep(ACE_Time_Value(0,5000));
+          DAF_OS::sleep(ACE_Time_Value(0,5000));
           value = sema.waiters();
 
           // Clear out the rest - test is over.
@@ -508,7 +508,7 @@ int main(int argc, char* argv[])
         case -1: break;
         case 'h': print_usage(cli_opt); return 0;
         case 'z': DAF::debug(true); test::debug=true; break;
-        case 'n': threadCount = ACE_OS::atoi(cli_opt.opt_arg());
+        case 'n': threadCount = DAF_OS::atoi(cli_opt.opt_arg());
     }
 
     ACE_UNUSED_ARG(threadCount);

--- a/tests/ServiceConfiguratorTest/ServiceConfiguratorTest.cpp
+++ b/tests/ServiceConfiguratorTest/ServiceConfiguratorTest.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
 {
     ConfigServiceLoader cfgLoader;
 
-    for (const char *daf_root = ACE_OS::getenv("DAF_ROOT"); daf_root;) {
+    for (const char *daf_root = DAF_OS::getenv("DAF_ROOT"); daf_root;) {
         ok_result.append(daf_root).append("/my bin"); break;
     }
 

--- a/tests/SyncValueTest/SyncValueTest.cpp
+++ b/tests/SyncValueTest/SyncValueTest.cpp
@@ -249,7 +249,7 @@ int test_SyncValueMultipleWaitersWithTimeout(int threadCount )
         }
 
         // Allow Timeout on waiter
-        ACE_OS::sleep(ACE_Time_Value(0, 50000));
+        DAF_OS::sleep(ACE_Time_Value(0, 50000));
 
         for (int i = count/2; i > 0 ; --i ) {
             value += sync.setValue(i);
@@ -302,7 +302,7 @@ int test_SyncValueMultipleWaitersWithTimeoutEarly(int threadCount )
         }
 
         // Allow Timeout on waiter
-        ACE_OS::sleep(ACE_Time_Value(0, 50000));
+        DAF_OS::sleep(ACE_Time_Value(0, 50000));
 
         for (int i = count/2; i > 0 ; --i ) {
             value += sync.setValue(i);
@@ -408,7 +408,7 @@ int test_SyncValueThreadKill(int threadCount )
 
         blocker.acquire();
 
-        ACE_OS::sleep(ACE_Time_Value(1));
+        DAF_OS::sleep(ACE_Time_Value(1));
 
         if (debug) ACE_DEBUG((LM_INFO, "(%P|%t) %T - Killing Executor\n"));
 
@@ -513,7 +513,7 @@ int main(int argc, char *argv[])
         case -1: break;
         case 'h': print_usage(cli_opt); return 0;
         case 'z': DAF::debug(true); test::debug=true; break;
-        case 'n': threadCount = ACE_OS::atoi(cli_opt.opt_arg());
+        case 'n': threadCount = DAF_OS::atoi(cli_opt.opt_arg());
     }
 
     std::cout << test::TEST_NAME << std::endl;

--- a/tests/TTY_AsynchTest/TTYSerialTest.cpp
+++ b/tests/TTY_AsynchTest/TTYSerialTest.cpp
@@ -268,7 +268,7 @@ int main ( int argc, char *argv[] )
     // going to do a short sleep to ensure the
     // aio is cleared out and we don't miss the
     // last trigger.
-    ACE_OS::sleep(testInterval);
+    DAF_OS::sleep(testInterval);
 
     const int expected = writer.count;
     const int result = reinterpret_cast<TEST::TestSerialHandler*>(device.get_device_handler())->get_count();

--- a/tests/TaskExecutorTest/TaskExecutorTest.cpp
+++ b/tests/TaskExecutorTest/TaskExecutorTest.cpp
@@ -61,7 +61,7 @@ namespace test
         {
             sema_counter.release();
             if ( debug ) ACE_DEBUG((LM_INFO, "%t - %T Sleeping for Time %d ms\n", delay.msec()));
-            ACE_OS::sleep(delay);
+            DAF_OS::sleep(delay);
             if ( debug ) ACE_DEBUG((LM_INFO, "%t - %T Exit Sleep\n"));
             int count = sema_counter.permits();
             if ( debug ) ACE_DEBUG((LM_INFO, "%t - %T %d Exit Sleep\n", count));
@@ -198,11 +198,11 @@ namespace test
             sema.release();
             if (long_or_short )
             {
-                ACE_OS::sleep(ACE_Time_Value(1,0));
+                DAF_OS::sleep(ACE_Time_Value(1,0));
             }
             else
             {
-                ACE_OS::sleep(ACE_Time_Value(0,100));
+                DAF_OS::sleep(ACE_Time_Value(0,100));
             }
 
             sema_post.release();
@@ -250,11 +250,11 @@ namespace test
             sema.release();
             if (long_or_short )
             {
-                ACE_OS::sleep(ACE_Time_Value(1,0));
+                DAF_OS::sleep(ACE_Time_Value(1,0));
             }
             else
             {
-                ACE_OS::sleep(ACE_Time_Value(0,100));
+                DAF_OS::sleep(ACE_Time_Value(0,100));
             }
 
             sema_post.release();
@@ -364,7 +364,7 @@ namespace test
             // Checking Debug on thread count --> output should decrement
             svc_blocker.release(1);
 
-            ACE_OS::sleep(ACE_Time_Value(0, 50000));
+            DAF_OS::sleep(ACE_Time_Value(0, 50000));
             // TODO work out how we can sync off this ?
 
             value = int(diff - executor.size());
@@ -377,7 +377,7 @@ namespace test
             if (debug) ACE_DEBUG((LM_INFO, "S2 Current Pool Size: %d\n", executor.size()));
 
             svc_blocker.release(1);
-            ACE_OS::sleep(ACE_Time_Value(0, 50000));
+            DAF_OS::sleep(ACE_Time_Value(0, 50000));
 
             if ( int(executor.size()) != (diff - 2) )
             {
@@ -515,10 +515,10 @@ namespace test
             while ( executor.size() > 0 )
             {
                 if ( debug ) ACE_DEBUG((LM_DEBUG, "%T Current Pool Size %d\n", executor.size()));
-                ACE_OS::sleep(ACE_Time_Value(DAF::TaskExecutor::THREAD_DECAY_TIMEOUT / 10000, 1000));
+                DAF_OS::sleep(ACE_Time_Value(DAF::TaskExecutor::THREAD_DECAY_TIMEOUT / 10000, 1000));
             }
 
-            //ACE_OS::sleep(ACE_Time_Value(DAF::TaskExecutor::THREAD_DECAY_LIMIT/1000, 10000));
+            // DAF_OS::sleep(ACE_Time_Value(DAF::TaskExecutor::THREAD_DECAY_LIMIT/1000, 10000));
             // TODO work out how we can sync off this ?
 
             value = int(diff - executor.size());
@@ -625,10 +625,10 @@ namespace test
             for ( attempts = 0; executor.size() > 0 && attempts < max_attempts; ++attempts)
             {
                 if ( debug ) ACE_DEBUG((LM_DEBUG, "%T Current Pool Size %d\n", executor.size()));
-                ACE_OS::sleep(ACE_Time_Value(0, TestKeepAliveTime_1 * 1000/(max_attempts-1)));
+                DAF_OS::sleep(ACE_Time_Value(0, TestKeepAliveTime_1 * 1000/(max_attempts-1)));
             }
             //value = (attempts < max_attempts);
-            //ACE_OS::sleep(ACE_Time_Value(0, (TestKeepAliveTime_1 + 1) * 1000));
+            //DAF_OS::sleep(ACE_Time_Value(0, (TestKeepAliveTime_1 + 1) * 1000));
 
             if (debug) ACE_DEBUG((LM_INFO, "S2 Current Pool Size: %d\n", executor.size()));
 
@@ -649,7 +649,7 @@ namespace test
             for ( attempts = 0; executor.size() > 0 && attempts < max_attempts; ++attempts)
             {
                 if ( debug ) ACE_DEBUG((LM_DEBUG, "%T  2 Current Pool Size %d\n", executor.size()));
-                ACE_OS::sleep(ACE_Time_Value(0, TestKeepAliveTime_2 * 1000/(max_attempts-1)));
+                DAF_OS::sleep(ACE_Time_Value(0, TestKeepAliveTime_2 * 1000/(max_attempts-1)));
             }
 
             if (debug) ACE_DEBUG((LM_INFO, "S3 Current Pool Size: %d\n", executor.size()));
@@ -703,7 +703,7 @@ namespace test
             task->long_or_short = 1;
 
             task->run();
-            ACE_OS::thr_yield();
+            DAF_OS::thr_yield();
             if (debug)
             {
                 ACE_DEBUG((LM_INFO, "%t - Task GrpId %d ThrCount %d\n", task->grp_id(), task->thr_count()));
@@ -754,7 +754,7 @@ namespace test
             // Crappy test..
             while ( task->thr_count() > 0 )
             {
-                ACE_OS::sleep(ACE_Time_Value(0, 100));
+                DAF_OS::sleep(ACE_Time_Value(0, 100));
             }
 
             if (debug)
@@ -765,7 +765,7 @@ namespace test
             task->long_or_short = 1;
 
             task->run();
-            ACE_OS::thr_yield();
+            DAF_OS::thr_yield();
             if (debug)
             {
                 ACE_DEBUG((LM_INFO, "%t - Task GrpId %d ThrCount %d\n", task->grp_id(), task->thr_count()));
@@ -847,7 +847,7 @@ namespace test
             ACE_DEBUG((LM_WARNING, ACE_TEXT("Exception caughtin %s\n"),__FUNCTION__)); expected = -1; // Forced Error Result
         }
 
-        ACE_OS::sleep(1);
+        DAF_OS::sleep(1);
         if ( thr_man && grp_id != -1)
         {
             const int THREAD_LIST_SIZE = 10;
@@ -914,7 +914,7 @@ namespace test
             ACE_DEBUG((LM_WARNING, ACE_TEXT("Exception caughtin %s\n"),__FUNCTION__)); expected = -1;
         }
 
-        ACE_OS::sleep(1);
+        DAF_OS::sleep(1);
         if ( thr_man && grp_id != -1)
         {
             const int THREAD_LIST_SIZE = 10;
@@ -971,7 +971,7 @@ namespace test
                     return -1;
                 }
 
-            } synchExecutor_(threads); ACE_OS::sleep(10);
+            } synchExecutor_(threads); DAF_OS::sleep(10);
 
         } catch (const std::exception &ex) {
             ACE_ERROR_RETURN((LM_INFO, ACE_TEXT("(%P | %t) Exception %s\n"), ex.what()), -3);
@@ -1011,7 +1011,7 @@ int main(int argc, char *argv[])
         case -1: break;
         case 'h': print_usage(cli_opt); return 0;
         case 'z': DAF::debug(10); test::debug = DAF::debug(); break;
-        case 'n': threadCount = ACE_OS::atoi(cli_opt.opt_arg());
+        case 'n': threadCount = DAF_OS::atoi(cli_opt.opt_arg());
     }
 
     ACE::debug(test::debug ? 1 : 0);

--- a/tests/WFMOEventTest/WFMOEventTest.cpp
+++ b/tests/WFMOEventTest/WFMOEventTest.cpp
@@ -87,8 +87,8 @@ MySignaller::MySignalHandler::handle_event(int sig, siginfo_t*, ucontext_t*)
 {
     this->timer_.stop();
     {
-        char s[128]; ACE_OS::sprintf(s, "(%u | %04u) Handler= %02d, Signal=%d "
-            , static_cast<int>(ACE_OS::getpid())
+        char s[128]; DAF_OS::sprintf(s, "(%u | %04u) Handler= %02d, Signal=%d "
+            , static_cast<int>(DAF_OS::getpid())
             , static_cast<int>(DAF_OS::thread_ID())
             , this->ident_
             , sig);
@@ -134,7 +134,7 @@ MySignaller::svc(void)
     int th_ident = thread_id++;
 
     for(int id = th_ident; this->is_active(); id += th_ident) {
-        this->handler_[id %= SIGNAL_HANDLER_MAX]->signal(); ACE_OS::sleep(ACE_Time_Value(0,1000));
+        this->handler_[id %= SIGNAL_HANDLER_MAX]->signal(); DAF_OS::sleep(ACE_Time_Value(0,1000));
     }
 
     return 0;


### PR DESCRIPTION
DAF_OS is used in some cases to override the behaviour supplied by ACE_OS implementations. In order to capture any more of these moving forward it should become the default practice to use DAF_OS. This is aiming to address #11.