### PR TITLE
Visual Studio 2017 support

### DIFF
--- a/DAF_vc12.bat
+++ b/DAF_vc12.bat
@@ -1,3 +1,0 @@
-perl %ACE_ROOT%/bin/mwc.pl -type vc12 -name_modifier *_vc12 -apply_project DAF.mwc
-pause
-

--- a/DAF_vs2017.bat
+++ b/DAF_vs2017.bat
@@ -1,0 +1,3 @@
+perl %ACE_ROOT%/bin/mwc.pl -type vs2017 -name_modifier *_vs2017 -apply_project DAF.mwc
+pause
+

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ develop:
 * Required
   * Perl
   * ACE-TAO 6.4.2+  [Vanderbilt](http://download.dre.vanderbilt.edu) | [GitHub](https://github.com/DOCGroup/ACE_TAO)
+    * Note ACE-TAO 6.4.3+ is required for Visual Studio 2017 support
+  * MPC [GitHub](https://github.com/DOCGroup/MPC) (if ACE-TAO is retrieved from GitHub)
 * Optional
   * OpenDDS 3.10+      [OpenDDS](http://opendds.org/downloads.html) | [GitHub](https://github.com/objectcomputing/OpenDDS)
 

--- a/TAF/TAF_no_tests_vs2017.bat
+++ b/TAF/TAF_no_tests_vs2017.bat
@@ -1,0 +1,3 @@
+perl %ACE_ROOT%/bin/mwc.pl -type vs2017 -name_modifier *_vs2017 -apply_project TAF_no_tests.mwc
+pause
+

--- a/TAF/TAF_vc12.bat
+++ b/TAF/TAF_vc12.bat
@@ -1,3 +1,0 @@
-perl %ACE_ROOT%/bin/mwc.pl -type vc12 -name_modifier *_vc12 -apply_project TAF.mwc
-pause
-

--- a/TAF/TAF_vc14.bat
+++ b/TAF/TAF_vc14.bat
@@ -1,3 +1,4 @@
-perl %ACE_ROOT%/bin/mwc.pl -type vc14 -name_modifier *_vc14 -apply_project -include %DAF_ROOT%/MPC/config -feature_file %DAF_ROOT%/MPC/config/TAF.features TAF.mwc
+perl %ACE_ROOT%/bin/mwc.pl -type vc14 -name_modifier *_vc14 -apply_project TAF.mwc
+
 pause
 

--- a/TAF/TAF_vs2017.bat
+++ b/TAF/TAF_vs2017.bat
@@ -1,0 +1,4 @@
+perl %ACE_ROOT%/bin/mwc.pl -type vs2017 -name_modifier *_vs2017 -apply_project TAF.mwc
+
+pause
+


### PR DESCRIPTION
Added new batch files and a note in the readme for Visual Studio 2017 support.
Removed old files related to vc12 since there is no active testing against it.
Addressed #6.