### PR TITLE
Removing exception specifications

### DIFF
--- a/GCRoute/GCLocation.cpp
+++ b/GCRoute/GCLocation.cpp
@@ -192,7 +192,7 @@ namespace GCRoute
     }
 
     GCLocation
-    GCRadial::radialIntersect(const GCRadial &loc) const throw (NoRadialIntersect)
+    GCRadial::radialIntersect(const GCRadial &loc) const
     {
         if (*this == loc) {
             return GCLocation(*this);

--- a/GCRoute/GCLocation.h
+++ b/GCRoute/GCLocation.h
@@ -277,7 +277,7 @@ namespace GCRoute
         GCRadian  maxLatitude(void) const;
 
         /* Intersecting Location of great circle radials */
-        GCLocation radialIntersect(const GCRadial&) const throw (NoRadialIntersect);
+        GCLocation radialIntersect(const GCRadial&) const;
     };
 
 } // namespace GCRoute

--- a/TAF/dds/DDSListener.h
+++ b/TAF/dds/DDSListener.h
@@ -34,7 +34,7 @@ namespace TAFDDS {
 
     struct TopicListener : virtual TAFDDS::Listener, virtual DDS::TopicListener
     {
-        virtual void on_inconsistent_topic(DDS::Topic_ptr, const DDS::InconsistentTopicStatus&) throw()
+        virtual void on_inconsistent_topic(DDS::Topic_ptr, const DDS::InconsistentTopicStatus&)
         {
             std::cout << "DDS::TopicListener::on_inconsistent_topic." << std::endl;
         }
@@ -42,34 +42,34 @@ namespace TAFDDS {
 
     struct DataWriterListener : virtual TAFDDS::Listener, virtual DDS::DataWriterListener
     {
-        virtual void on_offered_deadline_missed(DDS::DataWriter_ptr, const DDS::OfferedDeadlineMissedStatus&) throw ()
+        virtual void on_offered_deadline_missed(DDS::DataWriter_ptr, const DDS::OfferedDeadlineMissedStatus&)
         {
             std::cout << "DDS::DataWriterListener::on_offered_deadline_missed." << std::endl;
         }
 
-        virtual void on_offered_incompatible_qos(DDS::DataWriter_ptr, const DDS::OfferedIncompatibleQosStatus&) throw ()
+        virtual void on_offered_incompatible_qos(DDS::DataWriter_ptr, const DDS::OfferedIncompatibleQosStatus&)
         {
             std::cout << "DDS::DataWriterListener::on_offered_incompatible_qos." << std::endl;
         }
 
-        virtual void on_liveliness_lost(DDS::DataWriter_ptr, const DDS::LivelinessLostStatus&) throw ()
+        virtual void on_liveliness_lost(DDS::DataWriter_ptr, const DDS::LivelinessLostStatus&)
         {
             std::cout << "DDS::DataWriterListener::on_liveliness_lost." << std::endl;
         }
 
-        virtual void on_publication_matched(DDS::DataWriter_ptr, const DDS::PublicationMatchedStatus&) throw ()
+        virtual void on_publication_matched(DDS::DataWriter_ptr, const DDS::PublicationMatchedStatus&)
         {
             std::cout << "DDS::DataWriterListener::on_publication_matched." << std::endl;
         }
 
 #if defined(TAF_USES_NDDS)
 
-        virtual void on_reliable_writer_cache_changed(DDS::DataWriter_ptr, const DDS::ReliableWriterCacheChangedStatus&) throw ()
+        virtual void on_reliable_writer_cache_changed(DDS::DataWriter_ptr, const DDS::ReliableWriterCacheChangedStatus&)
         {
             std::cout << "DDS::DataWriterListener::on_reliable_writer_cache_changed." << std::endl;
         }
 
-        virtual void on_reliable_reader_activity_changed(DDS::DataWriter_ptr, const DDS_ReliableReaderActivityChangedStatus&) throw ()
+        virtual void on_reliable_reader_activity_changed(DDS::DataWriter_ptr, const DDS_ReliableReaderActivityChangedStatus&)
         {
             std::cout << "DDS::DataWriterListener::on_reliable_reader_activity_changed." << std::endl;
         }
@@ -79,37 +79,37 @@ namespace TAFDDS {
 
     struct DataReaderListener : virtual TAFDDS::Listener, virtual DDS::DataReaderListener
     {
-        virtual void on_data_available(DDS::DataReader_ptr) throw()
+        virtual void on_data_available(DDS::DataReader_ptr)
         {
             std::cout << "DDS::DataReaderListener::on_data_available." << std::endl;
         }
 
-        virtual void on_requested_deadline_missed(DDS::DataReader_ptr, const DDS::RequestedDeadlineMissedStatus&) throw ()
+        virtual void on_requested_deadline_missed(DDS::DataReader_ptr, const DDS::RequestedDeadlineMissedStatus&)
         {
             std::cout << "DDS::DataReaderListener::on_requested_deadline_missed." << std::endl;
         }
 
-        virtual void on_requested_incompatible_qos(DDS::DataReader_ptr, const DDS::RequestedIncompatibleQosStatus&)  throw ()
+        virtual void on_requested_incompatible_qos(DDS::DataReader_ptr, const DDS::RequestedIncompatibleQosStatus&)
         {
             std::cout << "DDS::DataReaderListener::on_requested_incompatible_qos." << std::endl;
         }
 
-        virtual void on_sample_rejected(DDS::DataReader_ptr, const DDS::SampleRejectedStatus&) throw ()
+        virtual void on_sample_rejected(DDS::DataReader_ptr, const DDS::SampleRejectedStatus&)
         {
             std::cout << "DDS::DataReaderListener::on_sample_rejected." << std::endl;
         }
 
-        virtual void on_liveliness_changed(DDS::DataReader_ptr, const DDS::LivelinessChangedStatus&)  throw ()
+        virtual void on_liveliness_changed(DDS::DataReader_ptr, const DDS::LivelinessChangedStatus&)
         {
             std::cout << "DDS::DataReaderListener::on_liveliness_changed." << std::endl;
         }
 
-        virtual void on_sample_lost(DDS::DataReader_ptr, const DDS::SampleLostStatus&) throw ()
+        virtual void on_sample_lost(DDS::DataReader_ptr, const DDS::SampleLostStatus&)
         {
             std::cout << "DDS::DataReaderListener::on_sample_lost." << std::endl;
         }
 
-        virtual void on_subscription_matched(DDS::DataReader_ptr, const DDS::SubscriptionMatchedStatus&) throw ()
+        virtual void on_subscription_matched(DDS::DataReader_ptr, const DDS::SubscriptionMatchedStatus&)
         {
             std::cout << "DDS::DataReaderListener::on_subscription_matched." << std::endl;
         }
@@ -117,7 +117,7 @@ namespace TAFDDS {
 
     struct PublisherListener    : virtual DDS::PublisherListener, virtual TAFDDS::DataWriterListener
     {
-        virtual void on_publication_matched(DDS::DataWriter_ptr, const DDS::PublicationMatchedStatus&) throw ()
+        virtual void on_publication_matched(DDS::DataWriter_ptr, const DDS::PublicationMatchedStatus&)
         {
             std::cout << "DDS::PublisherListener::on_publication_matched." << std::endl;
         }
@@ -125,12 +125,12 @@ namespace TAFDDS {
 
     struct SubscriberListener   : virtual DDS::SubscriberListener, virtual TAFDDS::DataReaderListener
     {
-        virtual void on_subscription_matched(DDS::DataReader_ptr, const DDS::SubscriptionMatchedStatus&) throw ()
+        virtual void on_subscription_matched(DDS::DataReader_ptr, const DDS::SubscriptionMatchedStatus&)
         {
             std::cout << "DDS::SubscriberListener::on_subscription_matched." << std::endl;
         }
 
-        virtual void on_data_on_readers(DDS::Subscriber_ptr) throw()
+        virtual void on_data_on_readers(DDS::Subscriber_ptr)
         {
             std::cout << "DDS::SubscriberListener::on_data_on_readers." << std::endl;
         }
@@ -141,12 +141,12 @@ namespace TAFDDS {
                                         virtual TAFDDS::PublisherListener,
                                         virtual TAFDDS::SubscriberListener
     {
-        virtual void on_publication_matched(DDS::DataWriter_ptr, const DDS::PublicationMatchedStatus&) throw ()
+        virtual void on_publication_matched(DDS::DataWriter_ptr, const DDS::PublicationMatchedStatus&)
         {
             std::cout << "DDS::DomainParticipantListener::on_publication_matched." << std::endl;
         }
 
-        virtual void on_subscription_matched(DDS::DataReader_ptr, const DDS::SubscriptionMatchedStatus&) throw ()
+        virtual void on_subscription_matched(DDS::DataReader_ptr, const DDS::SubscriptionMatchedStatus&)
         {
             std::cout << "DDS::DomainParticipantListener::on_subscription_matched." << std::endl;
         }

--- a/TAF/dds/DDSPubSub.h
+++ b/TAF/dds/DDSPubSub.h
@@ -362,7 +362,7 @@ namespace TAFDDS
 
         mutable ACE_SYNCH_MUTEX reader_lock_;
 
-        virtual void on_data_available(DDS::DataReader_ptr) throw();
+        virtual void on_data_available(DDS::DataReader_ptr);
 
     private:
 
@@ -396,7 +396,7 @@ namespace TAFDDS
 
         virtual DDS::ReturnCode_t on_data_available(const _data_type&);
 
-        virtual void on_data_available(DDS::DataReader_ptr) throw();
+        virtual void on_data_available(DDS::DataReader_ptr);
     };
 
 /***********************************************************************************/

--- a/TAF/dds/DDSPubSub_T.cpp
+++ b/TAF/dds/DDSPubSub_T.cpp
@@ -225,7 +225,7 @@ namespace TAFDDS
     }
 
     template <typename T_TOPIC, typename T_LISTENER> void
-    DDS_Reader<T_TOPIC,T_LISTENER>::on_data_available(DDS::DataReader_ptr rdr) throw()
+    DDS_Reader<T_TOPIC,T_LISTENER>::on_data_available(DDS::DataReader_ptr rdr)
     {
         ACE_Guard<ACE_SYNCH_MUTEX> read_guard(this->reader_lock_, false);
         if (read_guard.locked()) {
@@ -242,7 +242,7 @@ namespace TAFDDS
     }
 
     template <typename T_SUPPORT> void
-    TOPICReaderListener<T_SUPPORT>::on_data_available(DDS::DataReader_ptr rdr) throw()
+    TOPICReaderListener<T_SUPPORT>::on_data_available(DDS::DataReader_ptr rdr)
     {
         _data_reader_stub_type_ref d_rdr(rdr ? _support_type::narrow(rdr) : 0);
 

--- a/TAF/taf/CDRStream.cpp
+++ b/TAF/taf/CDRStream.cpp
@@ -38,7 +38,7 @@ namespace TAF
     }
 
     size_t
-    OutputCDR::copy_buffer(char *buf_ptr, size_t buf_length) const throw (DAF::IndexOutOfRange)
+    OutputCDR::copy_buffer(char *buf_ptr, size_t buf_length) const
     {
         if (buf_ptr && buf_length) {
 

--- a/TAF/taf/CDRStream.h
+++ b/TAF/taf/CDRStream.h
@@ -38,7 +38,7 @@ namespace TAF {
             return this->total_length();
         }
 
-        size_t  copy_buffer(char *buf_ptr, size_t buf_length) const throw (DAF::IndexOutOfRange);
+        size_t  copy_buffer(char *buf_ptr, size_t buf_length) const;
 
         // TODO: Need further specializations here (i.e. const char * etc)
     };

--- a/TAF/taf/IORQueryServant.cpp
+++ b/TAF/taf/IORQueryServant.cpp
@@ -35,7 +35,7 @@ namespace TAF
     }
 
     int
-    IORQueryServant::is_ident(const std::string &ident) const throw (CORBA::Exception)
+    IORQueryServant::is_ident(const std::string &ident) const
     {
         if (ident.length()) {
 

--- a/TAF/taf/IORQueryServant.h
+++ b/TAF/taf/IORQueryServant.h
@@ -47,7 +47,7 @@ namespace TAF
 
         const std::string & ident(void) const { return this->ident_; }
 
-        int is_ident(const std::string &ident) const throw (CORBA::Exception);
+        int is_ident(const std::string &ident) const;
 
     private:
 

--- a/TAF/taf/ORBManager.cpp
+++ b/TAF/taf/ORBManager.cpp
@@ -202,7 +202,7 @@ namespace TAF {
     }
 
     const TAF::NamingContext &
-    ORB::rootContext(ACE_Time_Value *timeout) const throw (CORBA::UserException)
+    ORB::rootContext(ACE_Time_Value *timeout) const
     {
         static ACE_SYNCH_MUTEX rootLock_;
 
@@ -241,7 +241,7 @@ namespace TAF {
     }
 
     const TAF::NamingContext &
-    ORB::baseContext(ACE_Time_Value *timeout) const throw (CORBA::UserException)
+    ORB::baseContext(ACE_Time_Value *timeout) const
     {
         static ACE_SYNCH_MUTEX baseLock_;
 

--- a/TAF/taf/ORBManager.h
+++ b/TAF/taf/ORBManager.h
@@ -82,8 +82,8 @@ namespace TAF
 
         const IORTable::Table_var &     IORTable(void) const;
 
-        const TAF::NamingContext &      rootContext(ACE_Time_Value *timeout = 0) const throw (CORBA::UserException);
-        const TAF::NamingContext &      baseContext(ACE_Time_Value *timeout = 0) const throw (CORBA::UserException);
+        const TAF::NamingContext &      rootContext(ACE_Time_Value *timeout = 0) const;
+        const TAF::NamingContext &      baseContext(ACE_Time_Value *timeout = 0) const;
 
         CORBA::Object_var   string_to_object(const std::string &s)  const;
         CORBA::String_var   object_to_string(CORBA::Object_ptr obj) const;

--- a/daf/Barrier.cpp
+++ b/daf/Barrier.cpp
@@ -108,7 +108,7 @@ namespace DAF
         }
     }
 
-    int     Barrier::barrier(void) throw (DAF::IllegalThreadStateException, DAF::BrokenBarrierException)
+    int     Barrier::barrier(void)
     {
         this->entryGate_.acquire();
 
@@ -155,7 +155,6 @@ namespace DAF
     }
 
     int   Barrier::barrier(time_t msecs)
-        throw (DAF::IllegalThreadStateException, DAF::BrokenBarrierException, DAF::TimeoutException)
     {
         if (this->entryGate_.attempt(msecs)) {
             throw TimeoutException();
@@ -210,7 +209,7 @@ namespace DAF
         return int(index);
     }
 
-    bool    Barrier::waitReset(time_t msecs) throw (DAF::IllegalThreadStateException)
+    bool    Barrier::waitReset(time_t msecs)
     {
         ACE_Guard<ACE_SYNCH_MUTEX> ace_mon( *this );
 

--- a/daf/Barrier.h
+++ b/daf/Barrier.h
@@ -122,8 +122,7 @@ namespace DAF
         * prematurely due to interruption or time-out. (If so,
         * the <code>broken</code> status is also set.)
         */
-        virtual int barrier(void)
-            throw (IllegalThreadStateException, BrokenBarrierException);
+        virtual int barrier(void);
 
         /**
         * Enter barrier and wait at most msecs for the other parties()-1 threads.
@@ -144,15 +143,14 @@ namespace DAF
         * the barrier. If the timeout occured while already in the
         * barrier, <code>broken</code> status is also set.
         */
-        int barrier(time_t msecs)
-            throw (IllegalThreadStateException, BrokenBarrierException, TimeoutException);
+        int barrier(time_t msecs);
 
         /**
         * Wait For the Barrier to reset after a barrier exchange
         * @return indicates <code>true</code> if the barrier was reset
         * ie all threads exited, <code>false</code> if an error occured.
         */
-        bool waitReset(time_t msecs = 0) throw (IllegalThreadStateException);
+        bool waitReset(time_t msecs = 0);
 
     private:
 

--- a/daf/Bitset.cpp
+++ b/daf/Bitset.cpp
@@ -50,7 +50,7 @@ namespace {
 
 namespace DAF
 {
-    Bitset::Bitset(size_t bits, bool val) throw (std::invalid_argument)
+    Bitset::Bitset(size_t bits, bool val)
         : bits_(bits), bit_buffer_(0)
     {
         if (ace_range(0, INT_MAX, int(bits)) == int(bits)) {
@@ -70,7 +70,7 @@ namespace DAF
         DAF_THROW_EXCEPTION(DAF::IllegalArgumentException);
     }
 
-    Bitset::Bitset(const Bitset &bitset) throw (std::runtime_error)
+    Bitset::Bitset(const Bitset &bitset)
         : bits_(bitset.bits()), bit_buffer_(0)
     {
         size_t len = this->size();
@@ -84,7 +84,7 @@ namespace DAF
     }
 
     Bitset::BIT_BYTE_ptr
-    Bitset::bit_buffer(size_t off) const throw (std::out_of_range)
+    Bitset::bit_buffer(size_t off) const
     {
         if (this->bits()) for (Bitset::BIT_BYTE_ptr p = this->bit_buffer_.get(); p;) {
 
@@ -126,7 +126,7 @@ namespace DAF
     }
 
     Bitset &
-    Bitset::operator = (const Bitset &bitset) throw (std::runtime_error)
+    Bitset::operator = (const Bitset &bitset)
     {
         if (this != &bitset) do { // Doing it to ourselves?
 
@@ -148,7 +148,7 @@ namespace DAF
     }
 
     Bitset &
-    Bitset::operator += (const Bitset &bitset) throw (std::runtime_error)
+    Bitset::operator += (const Bitset &bitset)
     {
         size_t pos = this->bits();
 
@@ -257,7 +257,7 @@ namespace DAF
     }
 
     Bitset
-    Bitset::subits(int pos, int len) const throw (std::out_of_range)
+    Bitset::subits(int pos, int len) const
     {
         if (*this && ace_range(0, int(this->bits() - 1), pos) == pos) {
             size_t bits = ace_min(this->bits() - pos, size_t(len));
@@ -270,7 +270,7 @@ namespace DAF
     }
 
     Bitset &
-    Bitset::erase(int pos, int len) throw (std::out_of_range)
+    Bitset::erase(int pos, int len)
     {
         if (*this && ace_range(0, int(this->bits() - 1), pos) == pos) {
             size_t bits = ace_min(this->bits() - pos, size_t(len));
@@ -292,7 +292,7 @@ namespace DAF
     }
 
     Bitset::bitraits
-    Bitset::operator [] (size_t bit) throw (std::out_of_range)
+    Bitset::operator [] (size_t bit)
     {
         if (*this && ace_range(size_t(0), this->bits() - 1, bit) == bit) {
             return bitraits(this->bit_buffer_[int(bit / BIT_BYTE_bits)], bit_mask(bit));
@@ -301,7 +301,7 @@ namespace DAF
     }
 
     bool
-    Bitset::operator [] (size_t bit) const throw (std::out_of_range)
+    Bitset::operator [] (size_t bit) const
     {
         if (*this && ace_range(size_t(0), this->bits() - 1, bit) == bit) {
             return (this->bit_buffer_[int(bit / BIT_BYTE_bits)] & bit_mask(bit)) ? true : false;
@@ -310,7 +310,7 @@ namespace DAF
     }
 
     Bitset &
-    Bitset::reset(size_t bits, bool val)  throw (std::invalid_argument)
+    Bitset::reset(size_t bits, bool val)
     {
         if (ace_range(0, INT_MAX, int(bits)) == int(bits)) {
             size_t len = bit_bytes(bits); this->bits_ = 0; // Clear out existing

--- a/daf/Bitset.h
+++ b/daf/Bitset.h
@@ -58,12 +58,12 @@ namespace DAF
         * \param bits is the capacity
         * \param init_val is the initializing value of the bit sequence
         */
-        Bitset(size_t bits = 0, bool init_val = false) throw (std::invalid_argument);
+        Bitset(size_t bits = 0, bool init_val = false);
 
         /**
         * Copy Constructor
         */
-        Bitset(const Bitset &) throw (std::runtime_error);
+        Bitset(const Bitset &);
 
         virtual ~Bitset(void) {}
 
@@ -108,7 +108,7 @@ namespace DAF
 
         /** Accessor to the Bit buffer
         \param off offset in bits to the returned pointer   */
-        BIT_BYTE_ptr bit_buffer(size_t off = 0) const throw (std::out_of_range);
+        BIT_BYTE_ptr bit_buffer(size_t off = 0) const;
 
         /// Pointer to the underlying bit sequence
         operator const void * () const
@@ -119,14 +119,14 @@ namespace DAF
         /** Array Accessor
         \param bit access the number 'bit' in the buffer
         \return value of the bit    */
-        bool        operator [] (size_t bit) const throw (std::out_of_range);
+        bool        operator [] (size_t bit) const;
         /// Access to allow rw access to a particular bit in the underlying bit sequence
-        bitraits    operator [] (size_t bit) throw (std::out_of_range);
+        bitraits    operator [] (size_t bit);
 
         /// Assign a Bitset from another Bitset sequence
-        Bitset &    operator  = (const Bitset &bitset) throw (std::runtime_error);
+        Bitset &    operator  = (const Bitset &bitset);
         /// Append a Bitset onto the end of an existing Bitset sequence
-        Bitset &    operator += (const Bitset &bitset) throw (std::runtime_error);
+        Bitset &    operator += (const Bitset &bitset);
 
         /** Compare Bit Buffers
         \param bitset buffer to compare against
@@ -160,14 +160,14 @@ namespace DAF
         \param len end of new buffer
         \return New Bitset class with subset of bits
          */
-        Bitset   subits(int pos, int len = EOF) const throw (std::out_of_range);
+        Bitset   subits(int pos, int len = EOF) const;
 
         /** Remove bits from the buffer
         Erase bits starting at a bit position for a maximum bit length; NOTE: remaining bits are left shifted after erase
         \param pos start position of bits for removal
         \param len number of bits to remove from buffer
         */
-        Bitset & erase(int pos, int len = EOF) throw (std::out_of_range);
+        Bitset & erase(int pos, int len = EOF);
 
         /// Invert all the bits in the bitset sequence
         Bitset & flip(void);
@@ -176,7 +176,7 @@ namespace DAF
         \param bits number of bits to reset value
         \param val the binary value to assign
         */
-        Bitset & reset(size_t bits, bool val = false) throw (std::invalid_argument);
+        Bitset & reset(size_t bits, bool val = false);
 
 
     protected:

--- a/daf/Channel_T.h
+++ b/daf/Channel_T.h
@@ -143,28 +143,28 @@ namespace DAF
         * subinterface are generally guaranteed to block on puts upon
         * reaching capacity, but other implementations may or may not block.
         */
-        virtual int put(const T&) throw (DAF::InternalException) = 0;
+        virtual int put(const T&) = 0;
 
         /**
         * Place item in channel only if it can be accepted within
         * ms milliseconds. The time bound is interpreted in
         * a coarse-grained, best-effort fashion.
         */
-        virtual int offer(const T&, time_t msecs = 0) throw (DAF::InternalException) = 0;
+        virtual int offer(const T&, time_t msecs = 0) = 0;
 
         /**
         * Return and remove an item from channel,
         * possibly waiting indefinitely until
         * such an item exists.
         */
-        virtual T   take(void) throw (DAF::InternalException) = 0;
+        virtual T   take(void) = 0;
 
         /**
         * Return and remove an item from channel only if one is available within
         * ms milliseconds. The time bound is interpreted in a coarse
         * grained, best-effort fashion.
         */
-        virtual T   poll(time_t msecs = 0) throw (DAF::InternalException, DAF::TimeoutException) = 0;
+        virtual T   poll(time_t msecs = 0) = 0;
 
 
         /// Empty the channel.

--- a/daf/ConstrainedExecutor.cpp
+++ b/daf/ConstrainedExecutor.cpp
@@ -102,7 +102,7 @@ namespace DAF
     }
 
     int
-    ConstrainedExecutor::execute(const Runnable_ref &command)  throw (InternalException)
+    ConstrainedExecutor::execute(const Runnable_ref &command)
     {
         return this->executor_.execute(new ConstraintRunnable(command, this->semaphore_));
     }

--- a/daf/ConstrainedExecutor.h
+++ b/daf/ConstrainedExecutor.h
@@ -55,7 +55,7 @@ namespace DAF
             */
             ConstrainedExecutor(Executor &executor, size_t permits = 1);
 
-            virtual int     execute(const Runnable_ref &command)  throw (InternalException);
+            virtual int     execute(const Runnable_ref &command);
 
             /// Remaining number of permitted concurrent jobs
             virtual size_t  available(void) const;

--- a/daf/DAF.cpp
+++ b/daf/DAF.cpp
@@ -339,7 +339,7 @@ namespace DAF
     }
 
     std::string
-    format_args(const std::string &args, bool substitute_env_args, bool quote_args) throw (DAF::IllegalArgumentException)
+    format_args(const std::string &args, bool substitute_env_args, bool quote_args)
     {
         ACE_ARGV args_argv(args.c_str(), substitute_env_args); DAF_ARGV params_argv(substitute_env_args);
 

--- a/daf/DAF.h
+++ b/daf/DAF.h
@@ -80,7 +80,7 @@ namespace DAF
     DAF_Export std::string  parse_args(const std::string &args, bool substitute_env_args = true, bool quote_args = true);
     DAF_Export std::string  parse_args(int argc, ACE_TCHAR *argv[], bool substitute_env_args = true, bool quote_args = true);
 
-    DAF_Export std::string  format_args(const std::string &args, bool substitute_env_args = true, bool quote_args = true) throw (DAF::IllegalArgumentException);
+    DAF_Export std::string  format_args(const std::string &args, bool substitute_env_args = true, bool quote_args = true);
 
     DAF_Export void         print_argv(const ACE_ARGV &);
     DAF_Export void         print_args(const std::string &args, bool substitute_env_args = false);
@@ -90,7 +90,7 @@ namespace DAF
 
     DAF_Export void         print_gestalt(const ACE_Service_Gestalt * sg = ACE_Service_Config::current());
 
-    DAF_Export std::string  locateServiceIdent(const ACE_Service_Object * svc_obj, const ACE_Service_Gestalt * sg = ACE_Service_Config::current()) throw (DAF::NotFoundException);
+    DAF_Export std::string  locateServiceIdent(const ACE_Service_Object * svc_obj, const ACE_Service_Gestalt * sg = ACE_Service_Config::current());
 
 
     /**

--- a/daf/DateTime.cpp
+++ b/daf/DateTime.cpp
@@ -239,7 +239,7 @@ namespace {
 
 namespace DAF
 {
-    Date_Time::Date_Time(const ACE_Date_Time &dt) throw (DateTimeException)
+    Date_Time::Date_Time(const ACE_Date_Time &dt)
         : ACE_Date_Time(dt)
     {
         if (assertDateRange(*this)) {
@@ -248,7 +248,7 @@ namespace DAF
         DAF_THROW_EXCEPTION(DAF::DateTimeException);
     }
 
-    Date_Time::Date_Time(const ACE_Time_Value &tv) throw (DateTimeException)
+    Date_Time::Date_Time(const ACE_Time_Value &tv)
         : ACE_Date_Time()
     {
         time_t tv_t = tv.sec();
@@ -271,7 +271,7 @@ namespace DAF
         DAF_THROW_EXCEPTION(DAF::DateTimeException);     // "DAF::Date invalid_time_value");
     }
 
-    Date_Time::Date_Time(long d, long m, long y, long hh, long mm, long sec, long usec) throw (DateTimeException)
+    Date_Time::Date_Time(long d, long m, long y, long hh, long mm, long sec, long usec)
         : ACE_Date_Time(d,m,y,hh,mm,sec,usec)
     {
         if (assertDateRange(*this)) {
@@ -280,7 +280,7 @@ namespace DAF
         DAF_THROW_EXCEPTION(DAF::DateTimeException);     // "DAF::Date invalid_time_value");
     }
 
-    Date_Time::Date_Time(const struct tm &s, long microsec) throw (DateTimeException)
+    Date_Time::Date_Time(const struct tm &s, long microsec)
         : ACE_Date_Time(  s.tm_mday         // day of the month         - [1,31]
                         , s.tm_mon  + 1     // month of the year        - [1,12]
                         , s.tm_year + 1900  // year
@@ -295,7 +295,7 @@ namespace DAF
         DAF_THROW_EXCEPTION(DAF::DateTimeException);     // "DAF::Date invalid_time_value");
     }
 
-    Date_Time::Date_Time(const std::string &s) throw (DateTimeException)
+    Date_Time::Date_Time(const std::string &s)
         : ACE_Date_Time()
     {
         for (int y, m, d, hh = 0, mm = 0, ss = 0, us = 0; s.length() > 0;) {

--- a/daf/DateTime.h
+++ b/daf/DateTime.h
@@ -91,11 +91,11 @@ namespace DAF
             }
 
             /** \todo{Fill this in} */
-            Date_Time(const ACE_Date_Time &)                throw (DAF::DateTimeException);
+            Date_Time(const ACE_Date_Time &);
             /** \todo{Fill this in} */
-            Date_Time(const ACE_Time_Value &)               throw (DAF::DateTimeException);
+            Date_Time(const ACE_Time_Value &);
             /** \todo{Fill this in} */
-            Date_Time(const struct tm &, long microsec = 0) throw (DAF::DateTimeException);
+            Date_Time(const struct tm &, long microsec = 0);
             /** \todo{Fill this in} */
             Date_Time( long day,
                        long month,
@@ -103,11 +103,11 @@ namespace DAF
                        long hour      = 0,
                        long minute    = 0,
                        long second    = 0,
-                       long microsec  = 0) throw (DAF::DateTimeException);
+                       long microsec  = 0);
 
             // Parse string using DAF_DATE_TIME_DEFAULT_FORMAT to build date_time
             /** \todo{Fill this in} */
-            Date_Time(const std::string &) throw (DAF::DateTimeException);
+            Date_Time(const std::string &);
 
             /** \todo{Fill this in} */
             operator ACE_Time_Value () const;

--- a/daf/DirectExecutor.h
+++ b/daf/DirectExecutor.h
@@ -49,7 +49,7 @@ namespace DAF
      */
     struct DAF_Export DirectExecutor : DAF::Executor {
 
-        virtual int execute(const DAF::Runnable_ref &command) throw (DAF::InternalException) {
+        virtual int execute(const DAF::Runnable_ref &command) {
             return (DAF::is_nil(command) ? 0 : command->run());
         }
     };

--- a/daf/Executor.h
+++ b/daf/Executor.h
@@ -59,7 +59,7 @@ namespace DAF
         * or error handler objects.
         * @param cmd Executes the provided runnable.
         */
-        virtual int     execute(const DAF::Runnable_ref&) throw (DAF::InternalException) = 0;
+        virtual int     execute(const DAF::Runnable_ref&) = 0;
 
         /**
         * The number of Runnables under the control of the Executor.

--- a/daf/FutureResult_T.cpp
+++ b/daf/FutureResult_T.cpp
@@ -56,7 +56,7 @@ namespace DAF
     }
 
     template <typename T, typename F> T
-    FutureResult<T,F>::get(void) const throw (InvocationTargetException)
+    FutureResult<T,F>::get(void) const
     {
         {
             ACE_Guard<ACE_SYNCH_MUTEX> ace_mon(*this);
@@ -80,7 +80,7 @@ namespace DAF
     }
 
     template <typename T, typename F> T
-    FutureResult<T,F>::get(time_t msecs) const throw (InvocationTargetException, TimeoutException)
+    FutureResult<T,F>::get(time_t msecs) const
     {
         bool timeout = false;
         {

--- a/daf/FutureResult_T.h
+++ b/daf/FutureResult_T.h
@@ -115,12 +115,11 @@ namespace DAF
         const T&    peek(void) const;
 
         /** \todo{Fill this in} */
-        T           get(void) const throw (DAF::InvocationTargetException);
+        T           get(void) const;
 
 
         /// Wait at most msecs to access the reference.
-        T           get(time_t msecs) const
-                        throw (DAF::InvocationTargetException, DAF::TimeoutException);
+        T           get(time_t msecs) const;
 
         /// Reset the value and error and set to not-ready, allowing this FutureResult to be reused. This is not particularly recommended and must be done only when you know that no other object is depending on the properties of this FutureResult.
         void        reset(void);

--- a/daf/LockedExecutor.h
+++ b/daf/LockedExecutor.h
@@ -49,7 +49,7 @@ namespace DAF
                 : lock_(lock)
             {}
 
-            virtual int execute(const DAF::Runnable_ref &cmd) throw (DAF::InternalException)
+            virtual int execute(const DAF::Runnable_ref &cmd)
             {
                 if (!is_nil(cmd)) {
                     ACE_GUARD_RETURN( LOCK, ace_mon, this->lock_, -1 );

--- a/daf/Monitor.h
+++ b/daf/Monitor.h
@@ -74,19 +74,19 @@ namespace DAF
         }
 
         /// Wait indefinately until condition is signalled.
-        int wait(const ACE_Time_Value *tv = 0) const throw (DAF::InternalException)
+        int wait(const ACE_Time_Value *tv = 0) const
         {
             return this->cond_mutex_.wait(tv);
         }
 
         /// Wait for upto ACE_Time_Value as an absolute TOD deadline or until condition is signalled.
-        int wait(const ACE_Time_Value &tv) const throw (DAF::InternalException)
+        int wait(const ACE_Time_Value &tv) const
         {
             return this->wait(&tv);
         }
 
         /// Wait for upto msec or until condition is signalled.
-        int wait(const time_t &msec) const throw (DAF::InternalException)
+        int wait(const time_t &msec) const
         {
             return this->wait(DAF_OS::gettimeofday(msec));
         }

--- a/daf/ObjectRef_T.cpp
+++ b/daf/ObjectRef_T.cpp
@@ -94,7 +94,7 @@ namespace DAF
     /// Function operators.
     template <typename T> inline
     typename ObjectRef<T>::_in_type
-    ObjectRef<T>::operator -> (void) const throw (DAF::INV_OBJREF)
+    ObjectRef<T>::operator -> (void) const
     {
         if (this->ptr_) {
             return this->ptr_;
@@ -104,7 +104,7 @@ namespace DAF
 
     template <typename T> inline
     typename ObjectRef<T>::_ref_type
-    ObjectRef<T>::operator * (void) const throw (DAF::INV_OBJREF)
+    ObjectRef<T>::operator * (void) const
     {
         if (this->ptr_) {
             return *this->ptr_;
@@ -190,7 +190,7 @@ namespace DAF
     }
 
     template <typename T> template <typename A>  // Support widening (C++11 Standard - Section 6.6.3)
-    ObjectRef<T>::operator ObjectRef<A> () const throw (DAF::INV_OBJREF)
+    ObjectRef<T>::operator ObjectRef<A> () const
     {
         for (A *ap = ObjectRefTraits<A>::narrow(this->ptr_);ap;) {
             return ObjectRef<A>(ap);
@@ -256,7 +256,7 @@ namespace DAF
 
     template <typename T> inline
     T *
-    ObjectRefOut<T>::operator -> (void) const throw (DAF::INV_OBJREF)
+    ObjectRefOut<T>::operator -> (void) const
     {
         if (this->ptr_) {
             return this->ptr_;

--- a/daf/ObjectRef_T.h
+++ b/daf/ObjectRef_T.h
@@ -127,13 +127,13 @@ namespace DAF
         ObjectRef<T> &operator = (const ObjectRef<T> &);
 
         /** \todo{Fill this in} */
-        _in_type    operator -> (void) const throw (DAF::INV_OBJREF);
+        _in_type    operator -> (void) const;
         /** \todo{Fill this in} */
-        _ref_type   operator *  (void) const throw (DAF::INV_OBJREF); // Not Part of the CORBA Standard
+        _ref_type   operator *  (void) const; // Not Part of the CORBA Standard
 
         /** \todo{Fill this in} */
         template <typename A>  // Support widening (C++11 Standard - Section 6.6.3)
-            operator ObjectRef<A> () const throw (DAF::INV_OBJREF);
+            operator ObjectRef<A> () const;
 
         /// Cast operators.
         /** \todo{Fill this in} */
@@ -215,7 +215,7 @@ namespace DAF
         T *& ptr(void);
 
         /** \todo{Fill this in} */
-        T *  operator -> (void) const throw (DAF::INV_OBJREF);
+        T *  operator -> (void) const;
 
     private:
 

--- a/daf/PropertyManager.cpp
+++ b/daf/PropertyManager.cpp
@@ -37,7 +37,7 @@ namespace DAF
     }
 
     std::string
-    PropertyManager::get_property(const property_key_type &ident, bool use_env) const throw (DAF::IllegalArgumentException)
+    PropertyManager::get_property(const property_key_type &ident, bool use_env) const
     {
         for (const property_key_type key(DAF::trim_string(ident)); key.length();) {
 

--- a/daf/PropertyManager.h
+++ b/daf/PropertyManager.h
@@ -70,7 +70,7 @@ namespace DAF
         the corresponding environment variable is not specified.
         \return property value
          */
-        std::string get_property(const property_key_type &ident, bool use_env = true) const throw (DAF::IllegalArgumentException);
+        std::string get_property(const property_key_type &ident, bool use_env = true) const;
 
         /**
         Access the property within the property map with a key value.
@@ -125,7 +125,7 @@ namespace DAF
         \sa #get_property
         */
         template <typename T>
-        T get_numeric_property(const property_key_type &ident, bool use_env = true) const throw (DAF::IllegalArgumentException);
+        T get_numeric_property(const property_key_type &ident, bool use_env = true) const;
 
         /**
         Templated variants to perform numeric conversion of the map's key value
@@ -146,7 +146,7 @@ namespace DAF
 
 
     template <typename T> inline T
-    PropertyManager::get_numeric_property(const property_key_type &ident, bool use_env) const throw (DAF::IllegalArgumentException)
+    PropertyManager::get_numeric_property(const property_key_type &ident, bool use_env) const
     {
         return static_cast<T>(DAF_OS::atof(this->get_property(ident, use_env).c_str()));
     }
@@ -166,7 +166,7 @@ namespace DAF
 
 
     template <> inline bool  /* Sepecialization for bool type property */
-    PropertyManager::get_numeric_property<bool>(const property_key_type &ident, bool use_env) const throw (DAF::IllegalArgumentException)
+    PropertyManager::get_numeric_property<bool>(const property_key_type &ident, bool use_env) const
     {
         const property_val_type val(this->get_property(ident, use_env));
         if (DAF_OS::strncasecmp(val.c_str(), ACE_TEXT("true"), 4) == 0) {
@@ -249,7 +249,7 @@ namespace DAF
 namespace DAF
 {
     template <typename T> inline T
-    get_numeric_property(const PropertyManager::property_key_type &ident, bool use_env = true) throw (DAF::IllegalArgumentException)
+    get_numeric_property(const PropertyManager::property_key_type &ident, bool use_env = true)
     {
         return ThePropertyRepository()->get_numeric_property<T>(ident, use_env);
     }
@@ -261,7 +261,7 @@ namespace DAF
     }
 
     inline std::string
-    get_property(const PropertyManager::property_key_type &ident, bool use_env = true) throw (DAF::IllegalArgumentException)
+    get_property(const PropertyManager::property_key_type &ident, bool use_env = true)
     {
         return ThePropertyRepository()->get_property(ident, use_env);
     }

--- a/daf/RefCount.cpp
+++ b/daf/RefCount.cpp
@@ -67,7 +67,7 @@ namespace DAF
     }
 
     /// Increment the reference count.
-    size_t  RefCount::_add_ref(void) throw (DAF::INV_OBJREF)
+    size_t  RefCount::_add_ref(void)
     {
         if (this->refCount_ > 0) try {  // DCL
             ACE_Guard<ACE_SYNCH_MUTEX> guard(this->refLock_); ACE_UNUSED_ARG(guard);
@@ -80,7 +80,7 @@ namespace DAF
     }
 
     /// Decrement the reference count.
-    size_t  RefCount::_remove_ref(void) throw (DAF::INV_OBJREF)
+    size_t  RefCount::_remove_ref(void)
     {
         if (this->refCount_ > 0) try {  // DCL
             do  {

--- a/daf/RefCount.h
+++ b/daf/RefCount.h
@@ -102,9 +102,10 @@ namespace DAF
         }
 
         /// Increment the reference count.
-        size_t  _add_ref(void) throw (DAF::INV_OBJREF);
+        size_t  _add_ref(void);
+
         /// Decrement the reference count.
-        size_t  _remove_ref(void) throw (DAF::INV_OBJREF);
+        size_t  _remove_ref(void);
 
     protected:
 

--- a/daf/Rendezvous_T.cpp
+++ b/daf/Rendezvous_T.cpp
@@ -77,7 +77,7 @@ namespace DAF
     }
 
     template <typename T, typename F> bool
-    Rendezvous<T,F>::waitReset(time_t msecs) throw (IllegalThreadStateException,InternalException)
+    Rendezvous<T,F>::waitReset(time_t msecs)
     {
         ACE_Guard<ACE_SYNCH_MUTEX> ace_mon( *this );
 

--- a/daf/Rendezvous_T.cpp
+++ b/daf/Rendezvous_T.cpp
@@ -104,7 +104,7 @@ namespace DAF
     }
 
     template <typename T, typename F> T
-    Rendezvous<T,F>::rendezvous(const T &t) throw (IllegalThreadStateException, BrokenBarrierException, InternalException)
+    Rendezvous<T,F>::rendezvous(const T &t)
     {
         this->entryGate_.acquire();
 
@@ -167,7 +167,6 @@ namespace DAF
 
     template <typename T, typename F> T
     Rendezvous<T,F>::rendezvous(const T &t, time_t msec)
-        throw (IllegalThreadStateException, BrokenBarrierException, TimeoutException, InternalException)
     {
         if (this->entryGate_.attempt(msec)) {
             throw TimeoutException();

--- a/daf/Rendezvous_T.h
+++ b/daf/Rendezvous_T.h
@@ -123,8 +123,7 @@ namespace DAF
         * Upon a Timeout occuring this will set the state to broken
         * and notify all existing waiters.
         */
-        bool    waitReset(time_t msecs = 0) throw (DAF::IllegalThreadStateException,
-                                                   DAF::InternalException);
+        bool    waitReset(time_t msecs = 0);
 
         /**
         * Enter a rendezvous; returning after all other parties arrive.
@@ -142,9 +141,7 @@ namespace DAF
         * Also returns as
         * broken if the RendezvousFunction encountered a run-time exception.
         */
-        T       rendezvous(const T &t_in)
-                    throw (DAF::IllegalThreadStateException, DAF::BrokenBarrierException,
-                    DAF::InternalException);
+        T       rendezvous(const T &t_in);
 
         /**
         * Wait msecs to complete a rendezvous.
@@ -166,10 +163,7 @@ namespace DAF
         * the exchange. If the timeout occured while already in the
         * exchange, <code>broken</code> status is also set.
         */
-        T      rendezvous(const T &t_in, time_t msec)
-                    throw (DAF::IllegalThreadStateException, DAF::BrokenBarrierException,
-                    DAF::TimeoutException,
-                    DAF::InternalException);
+        T      rendezvous(const T &t_in, time_t msec);
 
     private:
 

--- a/daf/Semaphore.cpp
+++ b/daf/Semaphore.cpp
@@ -80,7 +80,7 @@ namespace DAF
     {
     }
 
-    int Semaphore::acquire(void) throw (DAF::InternalException)
+    int Semaphore::acquire(void)
     {
         ACE_GUARD_REACTION(ACE_SYNCH_MUTEX, guard, *this, DAF_THROW_EXCEPTION(ResourceExhaustionException));
 
@@ -100,7 +100,7 @@ namespace DAF
         return 0;
     }
 
-    int Semaphore::attempt(time_t msecs) throw (DAF::InternalException)
+    int Semaphore::attempt(time_t msecs)
     {
         ACE_GUARD_REACTION(ACE_SYNCH_MUTEX, guard, *this, DAF_THROW_EXCEPTION(ResourceExhaustionException));
 

--- a/daf/Semaphore.h
+++ b/daf/Semaphore.h
@@ -85,9 +85,9 @@ namespace DAF
         }
 
         /** \todo{Fill this in} */
-        virtual int acquire(void) throw (DAF::InternalException);
+        virtual int acquire(void);
         /** \todo{Fill this in} */
-        virtual int attempt(time_t msecs) throw (DAF::InternalException);
+        virtual int attempt(time_t msecs);
         /** \todo{Fill this in} */
         virtual int release(void);
         /** \todo{Fill this in} */

--- a/daf/SemaphoreControlledChannel_T.cpp
+++ b/daf/SemaphoreControlledChannel_T.cpp
@@ -44,7 +44,7 @@ namespace DAF
     }
 
     template<typename T> int
-    SemaphoreControlledChannel<T>::put(const T &t) throw (DAF::InternalException)
+    SemaphoreControlledChannel<T>::put(const T &t)
     {
         if (this->putGuard_.acquire() == 0) try {
             if (this->insert(t) == 0) {
@@ -57,7 +57,7 @@ namespace DAF
     }
 
     template<typename T> int
-    SemaphoreControlledChannel<T>::offer(const T &t, time_t msecs) throw (DAF::InternalException)
+    SemaphoreControlledChannel<T>::offer(const T &t, time_t msecs)
     {
         if (this->putGuard_.attempt(msecs) == 0) try {
             if (this->insert(t) == 0) {
@@ -70,7 +70,7 @@ namespace DAF
     }
 
     template<typename T> T
-    SemaphoreControlledChannel<T>::take(void) throw (DAF::InternalException)
+    SemaphoreControlledChannel<T>::take(void)
     {
         this->takeGuard_.acquire();
 
@@ -87,7 +87,7 @@ namespace DAF
     }
 
     template<typename T> T
-    SemaphoreControlledChannel<T>::poll(time_t msecs) throw (DAF::InternalException, DAF::TimeoutException)
+    SemaphoreControlledChannel<T>::poll(time_t msecs)
     {
         if (this->takeGuard_.attempt(msecs)) switch (ACE_OS::last_error()) {
             case ETIME: DAF_THROW_EXCEPTION(DAF::TimeoutException); // Reverse the fact that we have been here and exit with error

--- a/daf/SemaphoreControlledChannel_T.h
+++ b/daf/SemaphoreControlledChannel_T.h
@@ -49,20 +49,20 @@ namespace DAF
         DAF::Semaphore  putGuard_, takeGuard_;
 
         virtual int insert(const T&) = 0;
-        virtual T   extract(void) throw (DAF::InternalException) = 0;
+        virtual T   extract(void) = 0;
 
     public:
         /** \todo{Fill this in} */
         SemaphoreControlledChannel(size_t capacity);
 
         /** \todo{Fill this in} */
-        virtual int put(const T&) throw (DAF::InternalException);
+        virtual int put(const T&);
         /** \todo{Fill this in} */
-        virtual int offer(const T&, time_t msecs = 0) throw (DAF::InternalException);
+        virtual int offer(const T&, time_t msecs = 0);
         /** \todo{Fill this in} */
-        virtual T   take(void) throw (DAF::InternalException);
+        virtual T   take(void);
         /** \todo{Fill this in} */
-        virtual T   poll(time_t msecs = 0) throw (DAF::InternalException, DAF::TimeoutException);
+        virtual T   poll(time_t msecs = 0);
 
 
         /** \todo{Fill this in} */

--- a/daf/SemaphoreControlledPriorityChannel_T.cpp
+++ b/daf/SemaphoreControlledPriorityChannel_T.cpp
@@ -40,7 +40,7 @@ namespace DAF
     }
 
     template < typename T, typename P > T
-    SemaphoreControlledPriorityChannel<T,P>::extract(void) throw (DAF::InternalException)
+    SemaphoreControlledPriorityChannel<T,P>::extract(void)
     {
         ACE_GUARD_REACTION(ACE_SYNCH_MUTEX, guard, *this, DAF_THROW_EXCEPTION(ResourceExhaustionException));
         T t(this->channelQ_.top());

--- a/daf/SemaphoreControlledPriorityChannel_T.h
+++ b/daf/SemaphoreControlledPriorityChannel_T.h
@@ -57,7 +57,7 @@ namespace DAF
         /** \todo{Fill this in} */
         virtual int insert(const T&);
         /** \todo{Fill this in} */
-        virtual T   extract(void) throw (DAF::InternalException);
+        virtual T   extract(void);
 
     private:
 

--- a/daf/SemaphoreControlledQueue_T.cpp
+++ b/daf/SemaphoreControlledQueue_T.cpp
@@ -40,7 +40,7 @@ namespace DAF
     }
 
     template <typename T> T
-    SemaphoreControlledQueue<T>::extract(void) throw (DAF::InternalException)
+    SemaphoreControlledQueue<T>::extract(void)
     {
         ACE_GUARD_REACTION(ACE_SYNCH_MUTEX, guard, *this, DAF_THROW_EXCEPTION(ResourceExhaustionException));
         T t(this->channelQ_.front());

--- a/daf/SemaphoreControlledQueue_T.h
+++ b/daf/SemaphoreControlledQueue_T.h
@@ -57,7 +57,7 @@ namespace DAF
         /** \todo{Fill this in} */
         virtual int insert(const T&);
         /** \todo{Fill this in} */
-        virtual T   extract(void) throw (DAF::InternalException);
+        virtual T   extract(void);
 
     private:
 

--- a/daf/ServiceGestalt.cpp
+++ b/daf/ServiceGestalt.cpp
@@ -116,7 +116,7 @@ namespace DAF
 #endif
 
     std::string
-    locateServiceIdent(const ACE_Service_Object *svc_obj, const ACE_Service_Gestalt *sg) throw (DAF::NotFoundException)
+    locateServiceIdent(const ACE_Service_Object *svc_obj, const ACE_Service_Gestalt *sg)
     {
         ACE_Service_Repository *repo = (sg ? const_cast<ACE_Service_Gestalt*>(sg)->current_service_repository() : 0);
 

--- a/daf/SynchValue_T.cpp
+++ b/daf/SynchValue_T.cpp
@@ -106,7 +106,7 @@ namespace DAF
     }
 
     template <typename T> int
-    SynchValue<T>::waitValue(const T &value) throw (InternalException)
+    SynchValue<T>::waitValue(const T &value)
     {
         if (this->value_ == value) { // DCL
             return 0;
@@ -144,8 +144,6 @@ namespace DAF
 
     template <typename T> int
     SynchValue<T>::waitValue(const T &value, time_t msec)
-        throw (InternalException, DAF::TimeoutException)
-
     {
         const ACE_Time_Value end_time(DAF_OS::gettimeofday(msec));
 

--- a/daf/SynchValue_T.h
+++ b/daf/SynchValue_T.h
@@ -131,9 +131,9 @@ namespace DAF
          *
          * @throw IllegalThreadStateException upon the SynchValue being destroyed while waiting
          */
-        virtual int waitValue(const T &value) throw (DAF::InternalException);
+        virtual int waitValue(const T &value);
 
-        virtual int waitValue(const T &value, time_t msec) throw (DAF::InternalException, DAF::TimeoutException);
+        virtual int waitValue(const T &value, time_t msec);
 
     };
 }  // namespace DAF

--- a/daf/SynchronousChannel_T.cpp
+++ b/daf/SynchronousChannel_T.cpp
@@ -60,7 +60,7 @@ namespace DAF
     }
 
     template <typename T> T
-    SynchronousChannel<T>::extract(void) throw (DAF::InternalException)
+    SynchronousChannel<T>::extract(void)
     {
         ACE_GUARD_REACTION(ACE_SYNCH_MUTEX, item_mon, *this, DAF_THROW_EXCEPTION(ResourceExhaustionException));
         T t(item_); this->item_ = T(); this->itemTaken_.release(); // Announce we have taken item
@@ -71,7 +71,7 @@ namespace DAF
     }
 
     template <typename T> T
-    SynchronousChannel<T>::take(void) throw (DAF::InternalException)
+    SynchronousChannel<T>::take(void)
     {
         this->unclaimedTakers_.release(); DAF_OS::thr_yield(); // Announce a taker
 
@@ -92,13 +92,13 @@ namespace DAF
     }
 
     template <typename T> int
-    SynchronousChannel<T>::put(const T &t) throw (DAF::InternalException)
+    SynchronousChannel<T>::put(const T &t)
     {
         this->unclaimedTakers_.acquire(); return this->insert(t);
     }
 
     template <typename T> T
-    SynchronousChannel<T>::poll(time_t msecs) throw (DAF::InternalException, DAF::TimeoutException)
+    SynchronousChannel<T>::poll(time_t msecs)
     {
         this->unclaimedTakers_.release(); DAF_OS::thr_yield();
 
@@ -122,7 +122,7 @@ namespace DAF
     }
 
     template <typename T> int
-    SynchronousChannel<T>::offer(const T &t, time_t msecs) throw (DAF::InternalException)
+    SynchronousChannel<T>::offer(const T &t, time_t msecs)
     {
         if (this->unclaimedTakers_.attempt(msecs) == 0) {
             return this->insert(t);

--- a/daf/SynchronousChannel_T.h
+++ b/daf/SynchronousChannel_T.h
@@ -71,7 +71,7 @@ namespace DAF
         // 1. This item has previously been acquired by caller
         // 2. Insert the item value, and signal item that it is ready
         // 3. Return item value.
-        virtual T   extract(void) throw (DAF::InternalException);
+        virtual T   extract(void);
 
     public:
 
@@ -82,14 +82,14 @@ namespace DAF
         * -# Wait until a taker arrives (via unclaimedTakers_ semaphore)
         * -# Assign item value using overloaded item assignment operator.
         */
-        virtual int put(const T &t) throw (DAF::InternalException);
+        virtual int put(const T &t);
 
         /**
         * Protocol is the same as put() except:
         * Backouts due to timeouts are allowed only during the wait
         * for takers. Upon claiming a taker, puts are forced to proceed.
         */
-        virtual int offer(const T &t, time_t msecs = 0) throw (DAF::InternalException);
+        virtual int offer(const T &t, time_t msecs = 0);
 
         /**
         * Basic protocol is:
@@ -98,7 +98,7 @@ namespace DAF
         * -# Wait until the item has a value.
         * -# Get the item value through item cast operator overload.
         */
-        virtual T   take(void) throw (DAF::InternalException);
+        virtual T   take(void);
 
         /**
         * Protocol is the same as take() except:
@@ -107,7 +107,7 @@ namespace DAF
         *   even here, if the put of an item we should get has already
         *   begun, we ignore the timeout and proceed.
         */
-        virtual T   poll(time_t msecs = 0) throw (DAF::InternalException, DAF::TimeoutException);
+        virtual T   poll(time_t msecs = 0);
 
         /**
         * Return the number of items currently in the channel.

--- a/daf/TaskExecutor.cpp
+++ b/daf/TaskExecutor.cpp
@@ -54,7 +54,7 @@ namespace DAF
     } // Ananomous
 
     template <> inline DAF::Runnable_ref
-    SynchronousChannel<DAF::Runnable_ref>::extract(void) throw (DAF::InternalException)
+    SynchronousChannel<DAF::Runnable_ref>::extract(void)
     {
         ACE_GUARD_REACTION(ACE_SYNCH_MUTEX, guard, *this, DAF_THROW_EXCEPTION(DAF::ResourceExhaustionException));
         DAF::Runnable_ref t(this->item_._retn()); this->itemTaken_.release();
@@ -349,7 +349,7 @@ namespace DAF
     }
 
     int
-    TaskExecutor::execute(const DAF::Runnable_ref &cmd) throw (DAF::InternalException)
+    TaskExecutor::execute(const DAF::Runnable_ref &cmd)
     {
         if (this->isAvailable()) try {
 
@@ -395,7 +395,7 @@ namespace DAF
     }
 
     int
-    TaskExecutor::task_handOff(const DAF::Runnable_ref &cmd) throw (DAF::InternalException)
+    TaskExecutor::task_handOff(const DAF::Runnable_ref &cmd)
     {
         if (this->isAvailable()) do {
             {

--- a/daf/TaskExecutor.h
+++ b/daf/TaskExecutor.h
@@ -158,7 +158,7 @@ namespace DAF
         * is an adaptation of "this", all of which invoke <DAF::Runnable::run>.
         * Returns -1 if handoff failure occurs otherwise 0.
         */
-        virtual int     execute(const DAF::Runnable_ref &) throw (DAF::InternalException);
+        virtual int     execute(const DAF::Runnable_ref &);
 
         /// Return the current thread count.  NOTE: support for the DAF::Executor interface
         virtual size_t  size(void) const    { return this->thr_count_;  }
@@ -276,7 +276,7 @@ namespace DAF
         * the new thread will coallesce back into the pool after the DAF::Runnable request
         * has been completed.
         */
-        virtual int task_handOff(const DAF::Runnable_ref &) throw (DAF::InternalException);
+        virtual int task_handOff(const DAF::Runnable_ref &);
 
         /**
         * Dispatch a DAF::Runnable within the context of an existing pool thread.


### PR DESCRIPTION
Exception specifications are now a deprecated feature from the C++ language. There are also circumstances where they can be problematic so this change will seek to remove them.