### PR TITLE
Removing subversion annotations

### DIFF
--- a/LDBC/SQLite/LDBCSQLite.mpc
+++ b/LDBC/SQLite/LDBCSQLite.mpc
@@ -1,5 +1,3 @@
-// $Id$
-
 project (LDBCSQLite) : ldbc_sqlite_defaults {
   sharedname     = *
   libout         = $(DAF_ROOT)/lib

--- a/tests/LDBCSQLiteTest/LDBCSQLiteTest.mpc
+++ b/tests/LDBCSQLiteTest/LDBCSQLiteTest.mpc
@@ -1,5 +1,3 @@
-// $Id$
-
 project (LDBCSQLiteTest) : ldbc_sqlite {
   exename     = *
   requires   += ldbc_sqlite


### PR DESCRIPTION
@jwillemsen noted we had left some subversion annotations in some files. This will hopefully remove the last of those.

There will still be a couple that come with the SQLite3 inclusion that don't belong to us.

Addresses issue #59.