### PR TITLE
Avoid gcc 6.2 destructor terminate warning

### DIFF
--- a/TAF/taf/CORBAInterfaceHandler_T.h
+++ b/TAF/taf/CORBAInterfaceHandler_T.h
@@ -82,7 +82,9 @@ namespace TAF
 
         virtual int init_bind_i(const std::string &name);
 
-        _interface_stub_var_type stub_reference_;
+        _interface_stub_var_type    stub_reference_;
+
+        bool    stub_activated_;
     };
 
 } // namespace TAF

--- a/TAF/taf/NamingContext.cpp
+++ b/TAF/taf/NamingContext.cpp
@@ -313,7 +313,9 @@ namespace TAF
 
     NamingContext::BindingIterator::~BindingIterator(void)
     {
-        if (!CORBA::is_nil(this->in())) try { (*this)->destroy(); } DAF_CATCH_ALL {}
+        if (!CORBA::is_nil(this->in())) {
+            (*this)->destroy();
+        }
     }
 
 } // namespace TAF


### PR DESCRIPTION
1) CORBAInterfaceHandler<> destructor now puts out an ERROR message warning that servant is still activated.  This typically means that fini_bind() has not been called. NOTE: message uses typeid(*this).name() so message is a fully qualified instance without needing to cash the particular name string argument.
2) NamingContext::BindingIterator destructor does not need the try {} catch.