### PR TITLE
IOR Resolver const fixes

### DIFF
--- a/TAF/taf/IORResolver_T.cpp
+++ b/TAF/taf/IORResolver_T.cpp
@@ -45,7 +45,7 @@ namespace TAF
 
     template <typename T>
     typename T::_var_type
-    IORResolver_T<T>::getResult(void)
+    IORResolver_T<T>::getResult(void) const
     {
         return T::_duplicate(this->result_.in());
     }
@@ -89,7 +89,7 @@ namespace TAF
 
     template <typename T>
     DAF::Monitor &
-    IORResolverChain_T<T>::getMonitor(void)
+    IORResolverChain_T<T>::getMonitor(void) const
     {
         return this->resultMonitor_;
     }

--- a/TAF/taf/IORResolver_T.h
+++ b/TAF/taf/IORResolver_T.h
@@ -39,7 +39,7 @@ namespace TAF
         IORResolver_T(const std::string &name, DAF::Monitor &mon);
         virtual ~IORResolver_T(void);
 
-        typename T::_var_type   getResult(void);
+        typename T::_var_type   getResult(void) const;
 
     protected:
         // Methods from DAF::Runnable
@@ -67,12 +67,12 @@ namespace TAF
         virtual ~IORResolverChain_T(void);
 
         int addResolver(const _resolver_ref_type &resolver);
-        DAF::Monitor & getMonitor(void);
+        DAF::Monitor & getMonitor(void) const;
         typename T::_var_type resolve(time_t timeout = DEFAULT_RESOLVE_TIMEOUT);
 
     private:
         DAF::TaskExecutor       executor_;
-        DAF::Monitor            resultMonitor_;
+        mutable DAF::Monitor    resultMonitor_;
     };
 
 


### PR DESCRIPTION
Really should have made the accessor methods const in the original implementation. This should fix that.