### PR TITLE
Multi orb initializer invocations

### DIFF
--- a/TAF/taf/ORBManager.h
+++ b/TAF/taf/ORBManager.h
@@ -124,21 +124,30 @@ namespace TAF
         ORB(void); // Managed by friendly singleton
 
         /* This ensures the ORB Singleton is statefull before the extension framework is bootstrapped */
-        static struct ORBInitializer : virtual PortableInterceptor::ORBInitializer, virtual CORBA::LocalObject
+        static class ORBInitializer : virtual public PortableInterceptor::ORBInitializer
+            , virtual public CORBA::LocalObject
         {
-            ORBInitializer(void)
+            bool pre_init_, post_init_;
+
+        public:
+
+            ORBInitializer(void) : pre_init_(false), post_init_(false)
             {
                 PortableInterceptor::register_orb_initializer(this);
             }
 
             virtual void pre_init(PortableInterceptor::ORBInitInfo_ptr info)
             {
-                TAF::ORBSingleton_type::instance()->pre_init(info);
+                if (this->pre_init_ ? false : this->pre_init_ = true)   {
+                    TAF::ORBSingleton_type::instance()->pre_init(info);
+                }
             }
 
             virtual void post_init(PortableInterceptor::ORBInitInfo_ptr info)
             {
-                TAF::ORBSingleton_type::instance()->post_init(info);
+                if (this->post_init_ ? false : this->post_init_ = true) {
+                    TAF::ORBSingleton_type::instance()->post_init(info);
+                }
             }
 
         } orbInitializer_;

--- a/TAF/taf/ORBManager.h
+++ b/TAF/taf/ORBManager.h
@@ -138,14 +138,14 @@ namespace TAF
 
             virtual void pre_init(PortableInterceptor::ORBInitInfo_ptr info)
             {
-                if (this->pre_init_ ? false : this->pre_init_ = true)   {
+                if (this->pre_init_ ? false : (this->pre_init_ = true))   {
                     TAF::ORBSingleton_type::instance()->pre_init(info);
                 }
             }
 
             virtual void post_init(PortableInterceptor::ORBInitInfo_ptr info)
             {
-                if (this->post_init_ ? false : this->post_init_ = true) {
+                if (this->post_init_ ? false : (this->post_init_ = true)) {
                     TAF::ORBSingleton_type::instance()->post_init(info);
                 }
             }

--- a/TAF/taf/extensions/TAFExtensions.cpp
+++ b/TAF/taf/extensions/TAFExtensions.cpp
@@ -62,7 +62,7 @@ namespace  {  // Anonymous
     void
     TAFExtensionsInitializer::pre_init(PortableInterceptor::ORBInitInfo_ptr info)
     {
-        if (this->pre_init_ ? false : this->pre_init_ = true) {
+        if (this->pre_init_ ? false : (this->pre_init_ = true)) {
             TAO_ORBInitInfo_var tao_info = TAO_ORBInitInfo::_narrow(info);
 
             if (CORBA::is_nil(tao_info.in())) {
@@ -74,7 +74,7 @@ namespace  {  // Anonymous
     void
     TAFExtensionsInitializer::post_init(PortableInterceptor::ORBInitInfo_ptr info)
     {
-        if (this->post_init_ ? false : this->post_init_ = true) {
+        if (this->post_init_ ? false : (this->post_init_ = true)) {
 
             TAO_ORBInitInfo_var tao_info = TAO_ORBInitInfo::_narrow(info);
 

--- a/TAF/taf/extensions/TAFExtensions.cpp
+++ b/TAF/taf/extensions/TAFExtensions.cpp
@@ -52,11 +52,11 @@ namespace  {  // Anonymous
         virtual void pre_init(PortableInterceptor::ORBInitInfo_ptr info);
         virtual void post_init(PortableInterceptor::ORBInitInfo_ptr info);
 
-    } tafExtensionsInitializer;
+    } tafExtensionsInitializer; DAF_UNUSED_STATIC(tafExtensionsInitializer);
 
     TAFExtensionsInitializer::TAFExtensionsInitializer(void) : pre_init_(false), post_init_(false)
     {
-        PortableInterceptor::register_orb_initializer(this); ACE_UNUSED_ARG(tafExtensionsInitializer); // Register this ORBInitializer
+        PortableInterceptor::register_orb_initializer(this); // Register this ORBInitializer
     }
 
     void


### PR DESCRIPTION
This merely puts a guard around the pre_init/post_init as we dont have a way of unregistering the ORBInitializer for both the Primary ORB and the Extensions Framework