### PR TITLE
Thread start synchronization

### DIFF
--- a/TAF/taf/GestaltService_impl.cpp
+++ b/TAF/taf/GestaltService_impl.cpp
@@ -34,7 +34,7 @@
 namespace
 {
     int
-    throw_last_error(int error = DAF_OS::last_error()) throw (CORBA::Exception)
+    throw_last_error(int error = DAF_OS::last_error())
     {
         switch (DAF_OS::last_error(error)) {
             case 0:         break;

--- a/TAF/tests/TAFServerLoader/TAFServerLoader.cpp
+++ b/TAF/tests/TAFServerLoader/TAFServerLoader.cpp
@@ -214,7 +214,7 @@ namespace {
         if (fn) {
             TAFSERVER_INIT_FUNCTION taf_server_init = reinterpret_cast<TAFSERVER_INIT_FUNCTION>(fn);
             if (taf_server_init) {
-                if (taf_server_init(argc, argv) ? false : this->libInit_ = true) {
+                if (taf_server_init(argc, argv) ? false : (this->libInit_ = true)) {
                     return 0;
                 }
             }

--- a/daf/CountDownSemaphore.cpp
+++ b/daf/CountDownSemaphore.cpp
@@ -39,16 +39,6 @@
 
 namespace DAF
 {
-    CountDownSemaphore::CountDownSemaphore(int count) : Monitor()
-        , count_(ace_max(0,count))
-    {
-    }
-
-    CountDownSemaphore::~CountDownSemaphore(void)
-    {
-        this->interrupt();
-    }
-
     int
     CountDownSemaphore::count(void) const
     {

--- a/daf/CountDownSemaphore.cpp
+++ b/daf/CountDownSemaphore.cpp
@@ -77,12 +77,12 @@ namespace DAF
         if (this->count() > 0) {
             while (count-- > 0) {
                 if (--this->count_ == 0) {
-                    break;
+                    return this->broadcast();
                 }
             }
         }
 
-        return this->broadcast();
+        return 0;
     }
 
 }  // namespace DAF

--- a/daf/CountDownSemaphore.cpp
+++ b/daf/CountDownSemaphore.cpp
@@ -72,7 +72,7 @@ namespace DAF
     int
     CountDownSemaphore::release(int count)
     {
-        ACE_GUARD_REACTION(_mutex_type, guard, *this, DAF_THROW_EXCEPTION(LockFailureException));
+        ACE_GUARD_RETURN(_mutex_type, guard, *this, (DAF_OS::last_error(ENOLCK), -1));
 
         if (this->count() > 0) {
             while (count-- > 0) {

--- a/daf/CountDownSemaphore.cpp
+++ b/daf/CountDownSemaphore.cpp
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -21,30 +21,6 @@
 #define DAF_COUNTDOWNSEMAPHORE_CPP
 
 /******************  CountDownSemaphore ************************
-*
-*(c)Copyright 2011,
-*   Defence Science and Technology Organisation,
-*   Department of Defence,
-*   Australia.
-*
-* All rights reserved.
-*
-* This is unpublished proprietary source code of DSTO.
-* The copyright notice above does not evidence any actual or
-* intended publication of such source code.
-*
-* The contents of this file must not be disclosed to third
-* parties, copied or duplicated in any form, in whole or in
-* part, without the express prior written permission of DSTO.
-*
-*
-* @file     CountDownSemaphore.cpp
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     1st September 2011
-* @version  $Revision$
-* @ingroup
-*
 * A CountDownSemaphore can serve as a simple one-shot
 * barrier that is initialized with a given count value.
 *
@@ -59,61 +35,61 @@
 
 #include "CountDownSemaphore.h"
 
+#include "Exception.h"
+
+#include <ace/Min_Max.h>
+
 namespace DAF
 {
-    CountDownSemaphore::CountDownSemaphore(int count)
-        : count_(count)
+    CountDownSemaphore::CountDownSemaphore(int count) : Monitor()
+        , count_(ace_max(0,count))
     {
     }
 
-    int CountDownSemaphore::acquire(void)
+    int
+    CountDownSemaphore::count(void) const
     {
-        ACE_GUARD_RETURN( ACE_SYNCH_MUTEX, ace_mon, *this, -1 );
-        while (this->count_ > 0) {
-            this->wait();
+        return this->count_;
+    }
+
+    int
+    CountDownSemaphore::acquire(const ACE_Time_Value * abstime)
+    {
+        ACE_GUARD_REACTION(_mutex_type, guard, *this, DAF_THROW_EXCEPTION(LockFailureException));
+
+        while (this->interrupted() || this->count() > 0) {
+            if (this->interrupted() ? DAF_OS::last_error(EINTR) : this->wait(abstime)) {
+                switch (DAF_OS::last_error()) {
+                case EINTR: DAF_THROW_EXCEPTION(InterruptedException);
+                case ETIME:
+                    if (0 >= this->count()) {
+                        continue; // Ensure we check interrupted before exit
+                    }
+
+                    // Fall through to report errno
+
+                default: return -1; // Return with errno.
+                }
+            }
         }
+
         return 0;
     }
 
-    int CountDownSemaphore::release(void)
+    int
+    CountDownSemaphore::release(int count)
     {
-        ACE_GUARD_RETURN( ACE_SYNCH_MUTEX, ace_mon, *this, -1 );
-        if (this->count_) {
-            if (--this->count_ == 0) {
-                return this->notifyAll(); return 0;
-            }
-        }
-        return -1;
-    }
+        ACE_GUARD_REACTION(_mutex_type, guard, *this, DAF_THROW_EXCEPTION(LockFailureException));
 
-    int CountDownSemaphore::release(int n)
-    {
-        ACE_GUARD_RETURN( ACE_SYNCH_MUTEX, ace_mon, *this, -1 );
-        if (this->count_) while (n-- > 0) {
-            if (--this->count_ == 0) {
-                this->notifyAll(); return (n ? -1 : 0);
-            }
-        }
-        return -1;
-    }
-
-    int CountDownSemaphore::attempt(time_t msecs)
-    {
-        ACE_GUARD_RETURN( ACE_SYNCH_MUTEX, ace_mon, *this, -1 );
-
-        if (this->count_ == 0) {
-            return 0;
-        } else if (msecs > 0) {
-
-            const ACE_Time_Value end_time(DAF_OS::gettimeofday(msecs));
-
-            do {
-                this->wait(end_time);
-                if (this->count_ == 0) {
-                    return 0;
+        if (this->count() > 0) {
+            while (count-- > 0) {
+                if (--this->count_ == 0) {
+                    break;
                 }
-            } while (end_time >= DAF_OS::gettimeofday());
+            }
         }
-        return -1;
+
+        return this->broadcast();
     }
+
 }  // namespace DAF

--- a/daf/CountDownSemaphore.cpp
+++ b/daf/CountDownSemaphore.cpp
@@ -37,13 +37,16 @@
 
 #include "Exception.h"
 
-#include <ace/Min_Max.h>
-
 namespace DAF
 {
     CountDownSemaphore::CountDownSemaphore(int count) : Monitor()
         , count_(ace_max(0,count))
     {
+    }
+
+    CountDownSemaphore::~CountDownSemaphore(void)
+    {
+        this->interrupt();
     }
 
     int

--- a/daf/CountDownSemaphore.cpp
+++ b/daf/CountDownSemaphore.cpp
@@ -72,7 +72,7 @@ namespace DAF
     int
     CountDownSemaphore::release(int count)
     {
-        ACE_GUARD_RETURN(_mutex_type, guard, *this, (DAF_OS::last_error(ENOLCK), -1));
+        ACE_GUARD_REACTION(_mutex_type, guard, *this, DAF_THROW_EXCEPTION(LockFailureException));
 
         if (this->count() > 0) {
             while (count-- > 0) {

--- a/daf/CountDownSemaphore.h
+++ b/daf/CountDownSemaphore.h
@@ -27,6 +27,8 @@
 
 #include "Monitor.h"
 
+#include <ace/Min_Max.h>
+
 namespace DAF
 {
     /** @class CountDownSemaphore
@@ -47,10 +49,14 @@ namespace DAF
         using Monitor::wait; // Hide Wait
 
     public:
-        /** \todo{Fill this in}   */
+
+        /** Constructor @a count >= 0 */
         CountDownSemaphore(int count);
 
-        /** \todo{Fill this in}   */
+        /** Destructor */
+        virtual ~CountDownSemaphore(void);
+
+        /** Current count value */
         int count(void) const;
 
         int acquire(const ACE_Time_Value *abstime = 0);

--- a/daf/CountDownSemaphore.h
+++ b/daf/CountDownSemaphore.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -23,14 +23,6 @@
 
 /**
 * ATTRIBUTION: Doug Lee Based On 'Concurrency Patterns in Java'
-*
-* @file     CountDownSemaphore.h
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     1st September 2011
-* @version  $Revision$
-* @ingroup  \todo{which group?}
-* @namespace DAF
 */
 
 #include "Monitor.h"
@@ -48,33 +40,54 @@ namespace DAF
      * subsequent acquires pass without blocking. This is a one-shot
      * phenomenon -- the count cannot be reset.
      * If you need a version that resets the count, consider
-     * using a CyclicBarrier.
+     * using a Barrier type.
      */
-    class DAF_Export CountDownSemaphore : DAF::Monitor
+    class DAF_Export CountDownSemaphore : protected Monitor
     {
-        volatile int count_;
+        using Monitor::wait; // Hide Wait
 
     public:
-
         /** \todo{Fill this in}   */
         CountDownSemaphore(int count);
 
         /** \todo{Fill this in}   */
-        int   count(void) const
-        {
-            return this->count_;
-        }
+        int count(void) const;
 
-        /** \todo{Fill this in}   */
-        virtual int acquire(void);
-        /** \todo{Fill this in}   */
-        virtual int attempt(time_t msecs);
+        int acquire(const ACE_Time_Value *abstime = 0);
+        int acquire(const ACE_Time_Value & abstime);
+        int acquire(time_t msecs);
 
-        /** \todo{Fill this in}   */
-        virtual int release(void);
-        /** \todo{Fill this in}   */
-        virtual int release(int n);
+        int attempt(time_t msecs); // Backwards Compatability
+
+        int release(int count = 1);
+
+        using Monitor::waiters;
+        using Monitor::interrupt;
+        using Monitor::interrupted;
+
+    private:
+
+        int count_;
     };
+
+    inline int
+    CountDownSemaphore::acquire(const ACE_Time_Value & tv)
+    {
+        return this->acquire(&tv);
+    }
+
+    inline int
+    CountDownSemaphore::acquire(time_t msecs)
+    {
+        return this->acquire(DAF_OS::gettimeofday(ace_max(msecs, time_t(0))));
+    }
+
+    inline int // Backwards Compatability
+    CountDownSemaphore::attempt(time_t msecs)
+    {
+        return this->acquire(msecs);
+    }
+
 }  // namespace DAF
 
 #endif // DAF_COUNTDOWNSEMAPHORE_H

--- a/daf/CountDownSemaphore.h
+++ b/daf/CountDownSemaphore.h
@@ -56,7 +56,7 @@ namespace DAF
         /** Current count value */
         int count(void) const;
 
-        int acquire(const ACE_Time_Value *abstime = 0);
+        int acquire(const ACE_Time_Value * abstime = 0);
         int acquire(const ACE_Time_Value & abstime);
         int acquire(time_t msecs);
 

--- a/daf/CountDownSemaphore.h
+++ b/daf/CountDownSemaphore.h
@@ -53,9 +53,6 @@ namespace DAF
         /** Constructor @a count >= 0 */
         CountDownSemaphore(int count);
 
-        /** Destructor */
-        virtual ~CountDownSemaphore(void);
-
         /** Current count value */
         int count(void) const;
 
@@ -75,6 +72,12 @@ namespace DAF
 
         int count_;
     };
+
+    inline
+    CountDownSemaphore::CountDownSemaphore(int count) : Monitor()
+        , count_(ace_max(0, count))
+    {
+    }
 
     inline int
     CountDownSemaphore::acquire(const ACE_Time_Value & tv)

--- a/daf/CountDownSemaphore.h
+++ b/daf/CountDownSemaphore.h
@@ -53,24 +53,39 @@ namespace DAF
         /** Constructor @a count >= 0 */
         CountDownSemaphore(int count);
 
-        /** Current count value */
+        /** Accessor to the current count value */
         int count(void) const;
 
+        /**
+        * If @a abstime == 0 then call acquire() directly for infinate time.
+        * Otherwise, block the acquiring thread until the count is 0 or
+        * until @a abstime times out, in which case -1 is returned
+        * with @c errno == @c ETIME.  Note that @a abstime is assumed to
+        * be in "absolute" rather than "relative" time.
+        */
         int acquire(const ACE_Time_Value * abstime = 0);
         int acquire(const ACE_Time_Value & abstime);
         int acquire(time_t msecs);
 
         int attempt(time_t msecs); // Backwards Compatability
 
+        /**
+        * Release (decrement) the current count by @a count and broadcast 
+        * to waiting acquirer's if 0. NOTE: underlying count will not be
+        * allowed to go negative.
+        */
         int release(int count = 1);
 
+        /**
+        * Allow public access to underlying Monitor capabilities
+        */
         using Monitor::waiters;
         using Monitor::interrupt;
         using Monitor::interrupted;
 
     private:
 
-        int count_;
+        int count_; // The current counter >= 0 always
     };
 
     inline

--- a/daf/Semaphore.cpp
+++ b/daf/Semaphore.cpp
@@ -90,7 +90,7 @@ namespace DAF
 
         if (permits > 0) {
 
-            ACE_GUARD_RETURN(_mutex_type, guard, *this, (DAF_OS::last_error(ENOLCK),-1));
+            ACE_GUARD_REACTION(_mutex_type, guard, *this, DAF_THROW_EXCEPTION(LockFailureException));
 
             while (permits-- > 0) {
                 ++this->permits_; if (this->signal()) {

--- a/daf/TaskExecutor.h
+++ b/daf/TaskExecutor.h
@@ -27,6 +27,7 @@
 
 #include "DAF.h"
 #include "Executor.h"
+#include "CountDownSemaphore.h"
 #include "SynchronousChannel_T.h"
 
 #include <ace/Task.h>
@@ -309,13 +310,13 @@ namespace DAF
 
     private:
 
-        class WorkerTask : public Runnable
+        class WorkerTask : public Runnable, public CountDownSemaphore
         {
             TaskExecutor * taskExecutor_;
 
         public:
 
-            WorkerTask(TaskExecutor *);
+            WorkerTask(TaskExecutor *, size_t threads);
 
             virtual int run(void);
 
@@ -378,7 +379,7 @@ namespace DAF
     /**********************************************************************************/
 
     inline
-    TaskExecutor::WorkerTask::WorkerTask(TaskExecutor * taskExecutor) : Runnable()
+    TaskExecutor::WorkerTask::WorkerTask(TaskExecutor * taskExecutor, size_t threads) : CountDownSemaphore(int(threads))
         , taskExecutor_(taskExecutor)
     {
     }
@@ -387,7 +388,7 @@ namespace DAF
 
     inline
     TaskExecutor::WorkerTaskExtended::WorkerTaskExtended(TaskExecutor * taskExecutor, const Runnable_ref & command)
-        : WorkerTask(taskExecutor), command_(command)
+        : WorkerTask(taskExecutor, 1), command_(command)
     {
     }
 


### PR DESCRIPTION
The TaskExecutor has a contract through execute() to ensure positive thread handoff.  This has been always honoured in the cases where an available thread is ready for the handoff, but was ignored in cases where threads were needed to be created.  This necessitated many applications to institute their own synchronisation where this behaviour needed to be guaranteed.  With this change the contract guarantee is now honoured even through thread creation.  This change is dependant on the CountDownSemaphore refactor branch as it is the vehicle used to ensure this guarantee efficiently.