### PR TITLE
Remove old comment blocks

### DIFF
--- a/TAF/examples/CORBAExample/CORBAClient.cpp
+++ b/TAF/examples/CORBAExample/CORBAClient.cpp
@@ -47,15 +47,6 @@
 # include "SIOP/SIOP.h"
 #endif
 
-// Derek's Desktop
-// -ORBObjRefStyle URL -ORBInitRef MySimpleServer=corbaloc::dsto-aar11972:8765/MySimpleServer
-// -ORBObjRefStyle URL -ORBInitRef MySimpleServer=corbaloc::131.185.25.12:8765/MySimpleServer
-// -ORBObjRefStyle URL -ORBInitRef MySimpleServer=corbaloc:iiop:1.2@dsto-aar11972:8765/MySimpleServer
-
-// Derek's Laptop
-// -ORBObjRefStyle URL -ORBInitRef MySimpleServer=corbaloc::131.185.25.23:8765/MySimpleServer
-// -ORBObjRefStyle URL -ORBInitRef MySimpleServer=corbaloc::aod-dsto100358:8765/MySimpleServer
-// -ORBObjRefStyle URL -ORBInitRef MySimpleServer=corbaloc:iiop:1.2@aod-dsto100358:8765/MySimpleServer
 
 struct HRTimer : ACE_High_Res_Timer {
     std::string msg_;

--- a/TAF/taf/ObjectStubRef_T.h
+++ b/TAF/taf/ObjectStubRef_T.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -21,27 +21,7 @@
 #ifndef TAF_OBJECTSTUBREF_T_H
 #define TAF_OBJECTSTUBREF_T_H
 
-/************************ ObjectStubRef *************************
-*
-* AUTHOR:   Derek Dominish <derek.dominish@dsto.defence.gov.au>
-* DATE:     21st December 2011
-*
-* TAF::ObjectStubRef provides a safe way of handling the conversion
-* of servant instances to CORBA object references while maintaining
-* responsibility for the lifecycle of the servant (based on scope).
-*
-* ImplVar represents ownership of servant lifecycle in the current process
-* (ie. is client/server-side neutral) and is intended solely for cases when
-* dealing with instances of a CORBA object and it's associated servant.
-*
-* For example, an application creating function objects for query
-* purposes needs control of the servant implementation but also
-* requires conversion to CORBA objects for integration with remote interfaces.
-*
-* This class presents an interface similar to that of the _var classes
-* provided by CORBA for managing proxies including reference counting.
-*
-*****************************************************************/
+
 
 #include "TAF.h"
 
@@ -66,6 +46,22 @@ namespace TAF
         static int  deactivate(PortableServer::Servant);
     };
 
+    /**
+     * TAF::ObjectStubRef provides a safe way of handling the conversion
+     * of servant instances to CORBA object references while maintaining
+     * responsibility for the lifecycle of the servant (based on scope).
+     *
+     * ImplVar represents ownership of servant lifecycle in the current process
+     * (ie. is client/server-side neutral) and is intended solely for cases when
+     * dealing with instances of a CORBA object and it's associated servant.
+     *
+     * For example, an application creating function objects for query
+     * purposes needs control of the servant implementation but also
+     * requires conversion to CORBA objects for integration with remote interfaces.
+     *
+     * This class presents an interface similar to that of the _var classes
+     * provided by CORBA for managing proxies including reference counting.
+     */
     template <typename T>
     class ObjectStubRef : public T::_stub_var_type
     {

--- a/TAF/taf/StringManager_T.h
+++ b/TAF/taf/StringManager_T.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -20,13 +20,6 @@
 ***************************************************************/
 #ifndef TAF_STRINGMANAGER_T_H
 #define TAF_STRINGMANAGER_T_H
-
-/************************ StringSequence_T *************************
-*
-* AUTHOR:   Derek Dominish <derek.dominish@dsto.defence.gov.au>
-* DATE:     30th March 2016
-*
-*****************************************************************/
 
 #include "VectorSequence_T.h"
 

--- a/TAF/taf/TAF.rc
+++ b/TAF/taf/TAF.rc
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -43,7 +43,7 @@ BEGIN
             VALUE "FileDescription", "TAF\0"
             VALUE "FileVersion", TAF_VERSION "\0"
             VALUE "InternalName", "TAFDLL\0"
-            VALUE "LegalCopyright", "Copyright 2011, Defence Science and Technology Organisation, Department of Defence. Australia.\0"
+            VALUE "LegalCopyright", "Copyright 2017, Defence Science and Technology Group, Department of Defence. Australia.\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "TAF.DLL\0"
             VALUE "ProductName", "TAF\0"

--- a/TAF/taf/VectorSequence_T.h
+++ b/TAF/taf/VectorSequence_T.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -21,12 +21,6 @@
 #ifndef TAF_VECTORSEQUENCE_T_H
 #define TAF_VECTORSEQUENCE_T_H
 
-/************************ VectorSequence_T *************************
-*
-* AUTHOR:   Derek Dominish <derek.dominish@dsto.defence.gov.au>
-* DATE:     30th March 2016
-*
-*****************************************************************/
 
 #include <tao/Basic_Types.h>
 

--- a/daf/ARGV.cpp
+++ b/daf/ARGV.cpp
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -20,32 +20,6 @@
 ***************************************************************/
 #define DAF_ARGV_CPP
 
-/************************ ARGV ******************************
-*
-*(c)Copyright 2011,
-*   Defence Science and Technology Organisation,
-*   Department of Defence,
-*   Australia.
-*
-* All rights reserved.
-*
-* This is unpublished proprietary source code of DSTO.
-* The copyright notice above does not evidence any actual or
-* intended publication of such source code.
-*
-* The contents of this file must not be disclosed to third
-* parties, copied or duplicated in any form, in whole or in
-* part, without the express prior written permission of DSTO.
-*
-*
-* @file     ARGV.h
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     1st September 2011
-* @version  $Revision$
-* @ingroup
-*
-****************************************************************/
 
 #include "ARGV.h"
 

--- a/daf/ConstrainedExecutor.cpp
+++ b/daf/ConstrainedExecutor.cpp
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -19,42 +19,6 @@
     License along with LASAGNE.  If not, see <http://www.gnu.org/licenses/>.
 ***************************************************************/
 #define DAF_CONSTRAINEDEXECUTOR_CPP
-
-/*****************************************************************************
- *
- *(c)Copyright 2011,
- *   Defence Science and Technology Organisation,
- *   Department of Defence,
- *   Australia.
- *
- * All rights reserved.
- *
- * This is unpublished proprietary source code of DSTO.
- * The copyright notice above does not evidence any actual or
- * intended publication of such source code.
- *
- * The contents of this file must not be disclosed to third
- * parties, copied or duplicated in any form, in whole or in
- * part, without the express prior written permission of DSTO.
- *
- *
- * @file     ConstrainedExecutor.cpp
- * @author   Derek Dominish
- * @author   $LastChangedBy$
- * @date     1st September 2011
- * @version  $Revision$
- * @ingroup
- *
- * ConstrainedExecutor encapsulates an Executor-derived class instance and constrains
- * that executor instance to only allowing a maximum number of threads to be run at any
- * one time.
- *
- * The ConstrainedExecutor is configured with this number on creation. Attempts
- * to run more than the maximum number of threads will block until currently running
- * threads exit from the encapsulated executor. Note that the ConstrainedExecutor does not
- * start its own threads, but uses the threads (and threading model) provided by the
- * encapsulated executor.
- */
 
 #include "ConstrainedExecutor.h"
 #include "DirectExecutor.h"

--- a/daf/Conversion.h
+++ b/daf/Conversion.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -33,17 +33,6 @@
 # endif
 #endif
 
-/**
-* Helper constants and functions for angle conversions
-*
-* @file     Conversion.h
-* @author
-* @author   $LastChangedBy$
-* @date
-* @version  $Revision$
-* @ingroup  \todo{which group?}
-* @namespace DAF
-*/
 
 namespace DAF
 {

--- a/daf/DAF.rc
+++ b/daf/DAF.rc
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -43,7 +43,7 @@ BEGIN
             VALUE "FileDescription", "DAF\0"
             VALUE "FileVersion", DAF_VERSION "\0"
             VALUE "InternalName", "DAFDLL\0"
-            VALUE "LegalCopyright", "Copyright 2011, Defence Science and Technology Organisation, Department of Defence. Australia.\0"
+            VALUE "LegalCopyright", "Copyright 2017, Defence Science and Technology Group, Department of Defence. Australia.\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "DAF.DLL\0"
             VALUE "ProductName", "DAF\0"

--- a/daf/DateTime.h
+++ b/daf/DateTime.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -20,18 +20,6 @@
 ***************************************************************/
 #ifndef DAF_DATETIME_H
 #define DAF_DATETIME_H
-
-/**
- * ATTRIBUTION: Based On OpenSource 'Date' - Runtime Borland C++ Builder 4
- *
- * @file     DateTime.h
- * @author   Derek Dominish
- * @author   $LastChangedBy$
- * @date     1st September 2011
- * @version  $Revision$
- * @ingroup
- * @namespace DAF
- */
 
 #include "DAF.h"
 
@@ -70,7 +58,7 @@ namespace DAF
     /** @class Date_Time
      * @brief Brief \todo { fill this in }
      *
-     * Detailed description \todo { fill this in }
+     * Based On OpenSource 'Date' - Runtime Borland C++ Builder 4
      */
     class DAF_Export Date_Time : public ACE_Date_Time
     {

--- a/daf/DirectExecutor.h
+++ b/daf/DirectExecutor.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -20,18 +20,6 @@
 ***************************************************************/
 #ifndef DAF_DIRECTEXECUTOR_H
 #define DAF_DIRECTEXECUTOR_H
-
-/**
-
-*
-* @file     DirectExecutor.h
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     1st September 2011
-* @version  $Revision$
-* @ingroup
-* @namespace DAF
-*/
 
 #include "Executor.h"
 

--- a/daf/Event_Handler.h
+++ b/daf/Event_Handler.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -24,16 +24,6 @@
 #include "RefCount.h"
 
 #include <ace/Event_Handler.h>
-
-/**
-* @file     Event_Handler.h
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     1st September 2011
-* @version  $Revision$
-* @ingroup
-* @namespace DAF
-*/
 
 namespace DAF
 {

--- a/daf/FutureResult_T.h
+++ b/daf/FutureResult_T.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -21,27 +21,12 @@
 #ifndef DAF_FUTURERESULT_T_H
 #define DAF_FUTURERESULT_T_H
 
-/**
-* ATTRIBUTION: Doug Lee Based On 'Concurrency Patterns in Java'
-*
-* @file     FutureResult_T.h
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     1st September 2011
-* @version  $Revision$
-* @ingroup
-* @namespace DAF
-*/
 
 #include "Monitor.h"
 #include "Runnable.h"
 
 namespace DAF
 {
-  /**
-   * A class maintaining a single reference variable serving as the result
-   * of an operation. The result cannot be accessed until it has been set.
-   **/
 
    /** @struct FutureFunctor
    * @brief A class maintaining a single reference variable serving as the result
@@ -70,7 +55,9 @@ namespace DAF
     /** @class FutureResult
     * @brief Brief \todo { fill this in }
     *
-    * Details \todo { fill this in }
+    * A class maintaining a single reference variable serving as the result
+    * of an operation. The result cannot be accessed until it has been set.
+    * ATTRIBUTION: Doug Lee Based On 'Concurrency Patterns in Java'
     *
     * \todo{Double check that the description in the struct shouldn't go here?}
     */

--- a/daf/ObjectRef_T.h
+++ b/daf/ObjectRef_T.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -20,18 +20,6 @@
 ***************************************************************/
 #ifndef DAF_OBJECTREF_T_H
 #define DAF_OBJECTREF_T_H
-
-/**
-* ATTRIBUTION: Based on the CORBA var specification and TAO implementation of proxy's
-*
-* @file     ObjectRef_T.h
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     21st December 2011
-* @version  $Revision$
-* @ingroup
-* @namespace DAF
-*/
 
 #include "DAF.h"
 
@@ -79,7 +67,8 @@ namespace DAF
     /** @class ObjectRef
     *@brief Brief \todo{Fill this in}
     *
-    * Details \todo{Detailed description}
+    * ATTRIBUTION: Based on the CORBA var specification and TAO implementation of proxies
+    * \todo{Detailed description}
     */
     template <typename T> class ObjectRef
     {

--- a/daf/RLECompressor.h
+++ b/daf/RLECompressor.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -22,28 +22,22 @@
 #ifndef DAF_RLECOMPRESSOR_H
 #define DAF_RLECOMPRESSOR_H
 
-/**
-* ATTRIBUTION: Based on IBM/Wang 'comp' machine instruction logics
-*
-* @file     RLECompressor.h
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     1st September 2011
-* @version  $Revision$
-* @ingroup
-* @namespace DAF
-*/
-
 #include <ace/Compression/rle/RLECompressor.h>
 
 namespace DAF {
-    /** \todo{Fill this in} */
+    /**
+     * ATTRIBUTION: Based on IBM/Wang 'comp' machine instruction logics
+     * \todo{Fill this in}
+     */
     inline int RLE_Compress(const void *in_ptr, size_t in_len, void *out_ptr, size_t out_len)
     {
         return int(ACE_RLECompressor().compress(in_ptr, in_len, out_ptr, out_len));
     }
 
-    /** \todo{Fill this in} */
+    /**
+    * ATTRIBUTION: Based on IBM/Wang 'comp' machine instruction logics
+    * \todo{Fill this in}
+    */
     inline int RLE_Expand(const void *in_ptr, size_t in_len, void *out_ptr, size_t out_len)
     {
         return int(ACE_RLECompressor().decompress(in_ptr, in_len, out_ptr, out_len));

--- a/daf/RefCount.cpp
+++ b/daf/RefCount.cpp
@@ -20,31 +20,6 @@
 ***************************************************************/
 #define DAF_REFCOUNT_CPP
 
-/**********************  RefCount *****************************
- *
- *(c)Copyright 2011,
- *   Defence Science and Technology Organisation,
- *   Department of Defence,
- *   Australia.
- *
- * All rights reserved.
- *
- * This is unpublished proprietary source code of DSTO.
- * The copyright notice above does not evidence any actual or
- * intended publication of such source code.
- *
- * The contents of this file must not be disclosed to third
- * parties, copied or duplicated in any form, in whole or in
- * part, without the express prior written permission of DSTO.
- *
- *
- * @file     RefCount.cpp
- * @author   Derek Dominish
- * @author   $LastChangedBy$
- * @date     1st September 2011
- * @version  $Revision$
- * @ingroup
- */
 
 #include "RefCount.h"
 

--- a/daf/SOCKEndpoint_T.h
+++ b/daf/SOCKEndpoint_T.h
@@ -21,15 +21,6 @@
 #ifndef DAF_SOCKENDPOINT_T_H
 #define DAF_SOCKENDPOINT_T_H
 
-/**
-* @file     SOCKEndpoint_T.h
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     1st June 2013
-* @version  $Revision$
-* @ingroup
-* @namespace DAF
-*/
 
 #include <ace/Synch.h>
 #include <ace/Synch_Traits.h>

--- a/daf/ServiceAdapter.h
+++ b/daf/ServiceAdapter.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -21,15 +21,6 @@
 #ifndef DAF_SERVICEADAPTER_H
 #define DAF_SERVICEADAPTER_H
 
-/**
-* @file     ServiceAdapter.h
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     1st September 2011
-* @version  $Revision$
-* @ingroup
-* @namespace DAF
-*/
 
 #include <ace/Service_Config.h>
 #include <ace/Service_Object.h>

--- a/daf/SignalHandler.h
+++ b/daf/SignalHandler.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -20,16 +20,6 @@
 ***************************************************************/
 #ifndef DAF_SIGNALHANDLER_H
 #define DAF_SIGNALHANDLER_H
-
-/**
-* @file     SignalHandler.h
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     1st September 2011
-* @version  $Revision$
-* @ingroup
-* @namespace DAF
-*/
 
 #include "DAF.h"
 

--- a/daf/SynchValue_T.h
+++ b/daf/SynchValue_T.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -21,15 +21,6 @@
 #ifndef DAF_SYNCHVALUE_T_H
 #define DAF_SYNCHVALUE_T_H
 
-/**
-* @file     SynchValue_T.h
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     1st September 2011
-* @version  $Revision$
-* @ingroup
-* @namespace DAF
-*/
 
 #include "Monitor.h"
 #include "Semaphore.h"

--- a/daf/WFMOSignalReactor.h
+++ b/daf/WFMOSignalReactor.h
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -22,15 +22,6 @@
 #ifndef DAF_WFMOSIGNALREACTOR_H
 #define DAF_WFMOSIGNALREACTOR_H
 
-/**
-* @file     WFMOSignalReactor.h
-* @author   Derek Dominish
-* @author   $LastChangedBy$
-* @date     1st September 2011
-* @version  $Revision$
-* @ingroup
-* @namespace DAF
-*/
 
 #include "DAF.h"
 #include "TaskExecutor.h"


### PR DESCRIPTION
Removed old subversion-related comment blocks and pieces that are no longer needed due to the way Git tracks things. Removed remnants of older copyright statements that seemed to get missed.