### PR TITLE
Removed extra formatting space when using '%#T' Log_Msg

### DIFF
--- a/TAF/training/ActiveService/ActiveService.cpp
+++ b/TAF/training/ActiveService/ActiveService.cpp
@@ -198,7 +198,7 @@ namespace LTM  // Open the LTM Namespace
     {
         ACE_UNUSED_ARG(act);
 
-        ACE_DEBUG((LM_INFO, ACE_TEXT("(%P | %t)\t%s[%@]::handle_timeout(%#T )\n")
+        ACE_DEBUG((LM_INFO, ACE_TEXT("(%P | %t)\t%s[%@]::handle_timeout(%#T)\n")
             , LTM_ActiveService::svc_ident()
             , this
             , &expected_time));

--- a/TAF/training/CORBActiveService/CORBActiveService.cpp
+++ b/TAF/training/CORBActiveService/CORBActiveService.cpp
@@ -276,7 +276,7 @@ namespace LTM  // Open the LTM Namespace
     {
         ACE_UNUSED_ARG(act);
 
-        ACE_DEBUG((LM_INFO, ACE_TEXT("(%P | %t)\t%s[%@]::handle_timeout(%#T )\n")
+        ACE_DEBUG((LM_INFO, ACE_TEXT("(%P | %t)\t%s[%@]::handle_timeout(%#T)\n")
             , LTM_CORBActiveService::svc_ident()
             , this
             , &expected_time));

--- a/TAF/training/DDSActiveService/DDSActiveService.cpp
+++ b/TAF/training/DDSActiveService/DDSActiveService.cpp
@@ -253,7 +253,7 @@ namespace LTM  // Open the LTM Namespace
     {
         ACE_UNUSED_ARG(act);
 
-        ACE_DEBUG((LM_INFO, ACE_TEXT("(%P | %t)\t%s[%@]::handle_timeout(%#T )\n")
+        ACE_DEBUG((LM_INFO, ACE_TEXT("(%P | %t)\t%s[%@]::handle_timeout(%#T)\n")
             , LTM_DDSActiveService::svc_ident()
             , this
             , &expected_time));

--- a/TAF/training/ReactiveService/ReactiveService.cpp
+++ b/TAF/training/ReactiveService/ReactiveService.cpp
@@ -174,7 +174,7 @@ namespace LTM  // Open the LTM Namespace
     {
         ACE_UNUSED_ARG(act);
 
-        ACE_DEBUG((LM_INFO, ACE_TEXT("(%P | %05t) %s[%@]::handle_timeout(%#T )\n")
+        ACE_DEBUG((LM_INFO, ACE_TEXT("(%P | %05t) %s[%@]::handle_timeout(%#T)\n")
             , LTM_ReactiveService::svc_ident()
             , this
             , &expected_time));


### PR DESCRIPTION
Removed extra space in formats that compensated for the errant leading space when using %#T Log_Msg formatting.  Reported to RemedyIT as bug #96. 

@jwillemsen  says:-

"I have extended the ACE_Log_Msg unit tests to validate that there is no leading space for %T, %#T, %D, and %#D. As reported there was one for %T and %#T which I fixed in ACE. This is going through CI testing right now."

 Thanks @jwillemsen for merging the fix into ACE 6.4.4.