### PR TITLE
DAF Bootstrap order requires 0_DAFInit initialized first under windows linkage

### DIFF
--- a/daf/0_DAFInit.cpp
+++ b/daf/0_DAFInit.cpp
@@ -18,7 +18,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with LASAGNE.  If not, see <http://www.gnu.org/licenses/>.
 ***************************************************************/
-#define DAF_DAFINIT_CPP
+#define DAF_0_DAFINIT_CPP
 
 #include <ace/OS.h>
 #include <ace/Init_ACE.h>
@@ -27,7 +27,7 @@
 #include <ace/High_Res_Timer.h>
 
 /*
-    BEWARE:  Changed filename to _DAFInit.cpp to ensure first in linkage order under VC
+    BEWARE:  Changed filename to 0_DAFInit.cpp to ensure first in linkage order under VC
     The anonymous namespace below defines a number of Global Variable "Loaders".
     Some items to be aware of are:
     - Runtime Global Variable creation and initialisation is dependent on the dynamic Loader's

--- a/daf/DAF.mpc
+++ b/daf/DAF.mpc
@@ -61,7 +61,7 @@ project(DAF) : dafbasedefaults, acelib {
   // NOTE: Forces Linux(GCC) to link in this order and bootstrap is consistant.
 
   Source_Files {
-    _DAFInit.cpp
+    0_DAFInit.cpp
     ARGV.cpp
     Barrier.cpp
     Bitset.cpp


### PR DESCRIPTION
Under Windows (Visual Studio), the linkage order of modules is controlled by the alphabetical ordering of module names (filenames).  With the DAF the original _DAFInit.cpp was named this specifically to ensure the underlying ACE resource environment was initialized prior to any other elements within the DAF as it contains the ACE::Init and primary reactor initialization logic.  However on windows the leading underbar (0x5F) had the effect of this module being the last in the linkage order regardless of mpc ordering and consequently the last to initialize its statics. By changing this to a leading '0' (0x30) the 0_DAFInit module correctly becomes the first.  Under linux (gcc) the mpc ordering is honoured so consistency will now be maintained between OS environments. This change could also mitigate possible static resource allocation race conditions.