### PR TITLE
Fixed warnings from errant typename usage with Clang compiler

### DIFF
--- a/daf/PropertyManager.h
+++ b/daf/PropertyManager.h
@@ -57,9 +57,9 @@ namespace DAF
     public:
 
         /** Upscope these meta types from protected configurator */
-        typedef typename Configurator::property_key_type    property_key_type;
-        typedef typename Configurator::property_val_type    property_val_type;
-        typedef typename Configurator::property_list_type   property_list_type;
+        typedef Configurator::property_key_type     property_key_type;
+        typedef Configurator::property_val_type     property_val_type;
+        typedef Configurator::property_list_type    property_list_type;
 
         /**
         Access the property within the property map with a key value.

--- a/daf/Semaphore.h
+++ b/daf/Semaphore.h
@@ -63,7 +63,7 @@ namespace DAF
 
     public:
 
-        typedef typename Monitor::_mutex_type _mutex_type;
+        typedef Monitor::_mutex_type    _mutex_type;
 
         /** Construct with initial permit count */
         Semaphore(int permits = 1); // Set default == 1 (Unlocked)

--- a/daf/ServiceGestaltLoader.h
+++ b/daf/ServiceGestaltLoader.h
@@ -56,9 +56,9 @@ namespace DAF
     {
     public:
 
-        typedef typename Configurator::property_key_type    property_key_type;
-        typedef typename Configurator::property_val_type    property_val_type;
-        typedef typename Configurator::value_type           value_type;
+        typedef Configurator::property_key_type     property_key_type;
+        typedef Configurator::property_val_type     property_val_type;
+        typedef Configurator::value_type            value_type;
 
     private:
 

--- a/tests/BitsetTest/BitsetTest.cpp
+++ b/tests/BitsetTest/BitsetTest.cpp
@@ -3,7 +3,7 @@
     Department of Defence,
     Australian Government
 
-	This file is part of LASAGNE.
+    This file is part of LASAGNE.
 
     LASAGNE is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as
@@ -183,7 +183,9 @@ int main(int argc, char *argv[])
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed in Differing Length ")), -1);
         }
         else {
-            DAF::Bitset test(MAX_BITS, true); if (test[1] = false) {
+            DAF::Bitset test(MAX_BITS, true);
+            test[1] = false;
+            if (test[1]) {
                 ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed in set Value ")), -1);
             }
             else if (test == bitset) {
@@ -199,7 +201,9 @@ int main(int argc, char *argv[])
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed with Same Bits ")), -1);
         }
         else {
-            DAF::Bitset test(MAX_BITS, true); if (test[1] = false) {
+            DAF::Bitset test(MAX_BITS, true);
+            test[1] = false;
+            if (test[1]) {
                 ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed in set Value ")), -1);
             }
             else if (test != bitset ? false : true) {
@@ -290,7 +294,8 @@ int main(int argc, char *argv[])
 
     std::cout << "Testing |= operator ";
     {
-        if (bitset[1] |= false) {
+        bitset[1] |= false;
+        if (bitset[1]) {
             ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("Failed (false | false) != false")), -1);
         }
         else if ((bitset[1] |= true) ? DAF_OS::memcmp(bitset, BUF_MAX_BITS_TRUE, bitset.size()) : true) {


### PR DESCRIPTION
Also removed implicit combined usage of cast operator with assignments