### PR TITLE
Two small fixes to DAF and TAF

### DIFF
--- a/TAF/TAF_CI.mwc
+++ b/TAF/TAF_CI.mwc
@@ -40,7 +40,6 @@ workspace {
   $(TAO_ROOT)/utils/nslist/nslist.mpc
 
   $(DDS_ROOT)/dds
-  $(DDS_ROOT)/tools
   $(DDS_ROOT)/java
 
   $(DAF_ROOT)/DAF.mwc
@@ -48,6 +47,7 @@ workspace {
 
   exclude {
     $(DDS_ROOT)/java/jms
+    $(DDS_ROOT)/tools
     $(DDS_ROOT)/tools/modeling/tests
   }
 

--- a/TAF/taf/IORResolver_T.cpp
+++ b/TAF/taf/IORResolver_T.cpp
@@ -164,10 +164,10 @@ namespace TAF
                 }
                 break;
             }
-        }
 
-        // Add our own delimiter '/' to the end
-        this->directory_.assign(bindDirectory).append(1, '/');
+            // Add our own delimiter '/' to the end
+            this->directory_.assign(bindDirectory).append(1, '/');
+        }
 
         // Ensure the name supplied will represent a file
         if (int(this->filename_.find_first_of('.')) <= 0)
@@ -192,7 +192,7 @@ namespace TAF
         std::string filename(DAF::trim_string(this->directory_ + this->filename_));
         if (filename.length())
         {
-            for (std::ifstream iorFile(filename_.c_str(), std::ios::in); iorFile;)
+            for (std::ifstream iorFile(filename.c_str(), std::ios::in); iorFile;)
             {
                 std::string iorFileString((std::istreambuf_iterator<char>(iorFile)), (std::istreambuf_iterator<char>()));
                 if (iorFileString.length())

--- a/daf/DAF.cpp
+++ b/daf/DAF.cpp
@@ -449,7 +449,7 @@ namespace DAF
             }
 
             if (arg.length()) { // Build the ARGV from backing list
-                params_argv.add(arg.c_str(), false); // Add this argument to the backing list
+                params_argv.add(arg.c_str(), true); // Add this argument to the backing list
             }
         }
 


### PR DESCRIPTION
DAF::format_args:
Keep arguments quoted. This fixes a bug in service configuration where quoted strings are not honoured all the way through to the service itself.

TAF::IORFileResolver_T:
Prevent adding trailing slash to empty directory path.
Use filename including directory when opening the input file stream.